### PR TITLE
Add option to hide cards during Collect phase

### DIFF
--- a/Extension/src/Retrospective.Hub.Extension/components/feedbackBoard.tsx
+++ b/Extension/src/Retrospective.Hub.Extension/components/feedbackBoard.tsx
@@ -123,7 +123,7 @@ export default class FeedbackBoard extends React.Component<FeedbackBoardProps, F
 
   private receiveUpdatedItemHandler = async (columnId: string, feedbackItemId: string) => {
     const updatedItem = await itemDataService.getFeedbackItem(this.props.board.id, feedbackItemId);
-    this.refreshFeedbackItems([updatedItem], this.props.hideFeedbackItems);
+    this.refreshFeedbackItems([updatedItem], false);
   }
 
   private initColumns = () => {

--- a/Extension/src/Retrospective.Hub.Extension/components/feedbackBoardContainer.tsx
+++ b/Extension/src/Retrospective.Hub.Extension/components/feedbackBoardContainer.tsx
@@ -73,42 +73,41 @@ export interface FeedbackBoardContainerState {
   isAutoResizeEnabled: boolean;
 }
 
-export default class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps, FeedbackBoardContainerState> {
+export default class FeedbackBoardContainer
+  extends React.Component<FeedbackBoardContainerProps, FeedbackBoardContainerState> {
   constructor(props: FeedbackBoardContainerProps) {
     super(props);
     this.state = {
+      allWorkItemTypes: [],
       boards: [],
       currentBoard: undefined,
       currentTeam: undefined,
       filteredProjectTeams: [],
       filteredUserTeams: [],
-      isAppInitialized: false,
-      isBackendServiceConnected: false,
-      isReconnectingToBackendService: false,
-      isSummaryDashboardVisible: false,
-      isTeamDataLoaded: false,
       isAllTeamsLoaded: false,
-      projectTeams: [],
-      userTeams: [],
-      nonHiddenWorkItemTypes: [],
-      allWorkItemTypes: [],
-
-      isPreviewEmailDialogHidden: true,
+      isAppInitialized: false,
+      isAutoResizeEnabled: true,
+      isBackendServiceConnected: false,
       isBoardCreationDialogHidden: true,
       isBoardUpdateDialogHidden: true,
+      isCarouselDialogHidden: true,
       isDeleteBoardConfirmationDialogHidden: true,
+      isDesktop: true,
+      isDropIssueInEdgeMessageBarVisible: true,
+      isLiveSyncInTfsIssueMessageBarVisible: true,
       isMobileBoardActionsDialogHidden: true,
       isMobileTeamSelectorDialogHidden: true,
+      isPreviewEmailDialogHidden: true,
+      isReconnectingToBackendService: false,
+      isSummaryDashboardVisible: false,
       isTeamBoardDeletedInfoDialogHidden: true,
+      isTeamDataLoaded: false,
       isTeamSelectorCalloutVisible: false,
+      nonHiddenWorkItemTypes: [],
+      projectTeams: [],
       teamBoardDeletedDialogMessage: '',
       teamBoardDeletedDialogTitle: '',
-      isCarouselDialogHidden: true,
-      isLiveSyncInTfsIssueMessageBarVisible: true,
-      isDropIssueInEdgeMessageBarVisible: true,
-      
-      isDesktop: true,
-      isAutoResizeEnabled: true,
+      userTeams: [],
     };
   }
 
@@ -664,6 +663,7 @@ export default class FeedbackBoardContainer extends React.Component<FeedbackBoar
       [TelemetryEventProperties.OldWorkflowPhase]: this.state.currentBoard.activePhase,
       [TelemetryEventProperties.NewWorkflowPhase]: newPhase
     });
+
     this.setState(prevState => {
       const updatedCurrentBoard = prevState.currentBoard;
       updatedCurrentBoard.activePhase = newPhase;
@@ -674,8 +674,8 @@ export default class FeedbackBoardContainer extends React.Component<FeedbackBoar
     });
   }
 
-  private createBoard = async (title: string, columns: IFeedbackColumn[], isBoardAnonymous: boolean) => {
-    const createdBoard = await boardDataService.createBoardForTeam(this.state.currentTeam.id, title, columns, isBoardAnonymous);
+  private createBoard = async (title: string, columns: IFeedbackColumn[], isBoardAnonymous: boolean, shouldShowFeedbackAfterCollect: boolean) => {
+    const createdBoard = await boardDataService.createBoardForTeam(this.state.currentTeam.id, title, columns, isBoardAnonymous, shouldShowFeedbackAfterCollect);
     await this.reloadBoardsForCurrentTeam();
     this.hideBoardCreationDialog();
     reflectBackendService.broadcastNewBoard(this.state.currentTeam.id, createdBoard.id);
@@ -780,7 +780,10 @@ export default class FeedbackBoardContainer extends React.Component<FeedbackBoar
     dialogTitle: string,
     placeholderText: string,
     initialValue: string,
-    onSubmit: (title: string, columns: IFeedbackColumn[], isBoardAnonymous: boolean) => void,
+    onSubmit: (
+        title: string, columns: IFeedbackColumn[],
+        isBoardAnonymous: boolean, shouldShowFeedbackAfterCollect: boolean,
+      ) => void,
     onCancel: () => void) => {
     return (
       <Dialog
@@ -1137,6 +1140,10 @@ export default class FeedbackBoardContainer extends React.Component<FeedbackBoar
                       isCarouselDialogHidden={this.state.isCarouselDialogHidden}
                       hideCarouselDialog={this.hideCarouselDialog}
                       isAnonymous={this.state.currentBoard.isAnonymous ? this.state.currentBoard.isAnonymous : false}
+                      hideFeedbackItems={this.state.currentBoard.shouldShowFeedbackAfterCollect ? 
+                        this.state.currentBoard.activePhase == WorkflowPhase.Collect && this.state.currentBoard.shouldShowFeedbackAfterCollect : 
+                        false
+                      }
                     />
                   </div>
                   <Dialog

--- a/Extension/src/Retrospective.Hub.Extension/components/feedbackColumn.tsx
+++ b/Extension/src/Retrospective.Hub.Extension/components/feedbackColumn.tsx
@@ -34,9 +34,13 @@ export interface FeedbackColumnProps {
   allWorkItemTypes: WorkItemType[];
   isBoardAnonymous: boolean;
   shouldFocusOnCreateFeedback: boolean;
+  hideFeedbackItems: boolean;
 
-  addFeedbackItems: (columnId: string, columnItems: IFeedbackItemDocument[], shouldBroadcast: boolean, newlyCreated: boolean, showAddedAnimation: boolean, shouldHaveFocus: boolean) => void;
-  removeFeedbackItemFromColumn: (columnIdToDeleteFrom: string, feedbackItemIdToDelete: string, shouldSetFocusOnFirstAvailableItem: boolean) => void;
+  addFeedbackItems: (
+    columnId: string, columnItems: IFeedbackItemDocument[], shouldBroadcast: boolean,
+    newlyCreated: boolean, showAddedAnimation: boolean, shouldHaveFocus: boolean, hideFeedbackItems: boolean) => void;
+  removeFeedbackItemFromColumn: (
+    columnIdToDeleteFrom: string, feedbackItemIdToDelete: string, shouldSetFocusOnFirstAvailableItem: boolean) => void;
   refreshFeedbackItems: (feedbackItems: IFeedbackItemDocument[], shouldBroadcast: boolean) => void;
 }
 
@@ -51,8 +55,8 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
   constructor(props: FeedbackColumnProps) {
     super(props);
     this.state = {
+      isCarouselHidden: true,
       isCollapsed: false,
-      isCarouselHidden: true
     };
   }
 
@@ -65,30 +69,32 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
   }
 
   public createEmptyFeedbackItem = () => {
-    const item = this.props.columnItems.find(x => x.feedbackItem.id === 'emptyFeedbackItem');
+    const item = this.props.columnItems.find((x) => x.feedbackItem.id === 'emptyFeedbackItem');
     if (item) {
-      // Don't create another empty feedback item if one already exists. 
+      // Don't create another empty feedback item if one already exists.
       return;
     }
 
     const userIdentity = getUserIdentity();
     const feedbackItem: IFeedbackItemDocument = {
-      id: 'emptyFeedbackItem',
       boardId: this.props.boardId,
-      title: '',
       columnId: this.props.columnId,
       createdBy: this.props.isBoardAnonymous ? null : userIdentity,
       createdDate: new Date(Date.now()),
-      upvotes: 0
-    }
-    
+      id: 'emptyFeedbackItem',
+      title: '',
+      upvotes: 0,
+      userIdRef: userIdentity.id,
+    };
+
     this.props.addFeedbackItems(
       this.props.columnId,
       [feedbackItem],
       /*shouldBroadcast*/ false,
       /*newlyCreated*/ true,
       /*showAddedAnimation*/ false,
-      /*shouldHaveFocus*/ false);
+      /*shouldHaveFocus*/ false,
+      /*hideFeedbackItems*/ false);
   }
 
   public dragFeedbackItemOverColumn = (e: React.DragEvent<HTMLDivElement>) => {
@@ -164,6 +170,8 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
       allWorkItemTypes: columnProps.allWorkItemTypes,
       isInteractable: isInteractable,
       shouldHaveFocus: columnItem.shouldHaveFocus ? true : false,
+      hideFeedbackItems: columnProps.hideFeedbackItems,
+      userIdRef: columnItem.feedbackItem.userIdRef,
     }
   }
 

--- a/Extension/src/Retrospective.Hub.Extension/css/feedbackItem.scss
+++ b/Extension/src/Retrospective.Hub.Extension/css/feedbackItem.scss
@@ -19,6 +19,10 @@
     }
   }
 
+  &.hideFeedbackItem {
+    display: none;
+  }
+
   .document-card-wrapper {
     position: relative;
   }

--- a/Extension/src/Retrospective.Hub.Extension/css/feedbackItem.scss
+++ b/Extension/src/Retrospective.Hub.Extension/css/feedbackItem.scss
@@ -19,8 +19,8 @@
     }
   }
 
-  &.hideFeedbackItem {
-    display: none;
+  &.hideFeedbackItem .card-content {
+    filter: blur(3px);
   }
 
   .document-card-wrapper {

--- a/Extension/src/Retrospective.Hub.Extension/interfaces/feedback.tsx
+++ b/Extension/src/Retrospective.Hub.Extension/interfaces/feedback.tsx
@@ -23,6 +23,7 @@ export interface IFeedbackBoardDocument {
   modifiedBy?: IdentityRef;
   activePhase: WorkflowPhase;
   isAnonymous?: boolean;
+  shouldShowFeedbackAfterCollect?: boolean;
 }
 
 export interface IFeedbackColumn {
@@ -38,8 +39,8 @@ export interface IFeedbackItemDocument {
   boardId: string;
   title: string;
   description?: string;
-  childFeedbackItemIds?: string[]
-  parentFeedbackItemId?: string
+  childFeedbackItemIds?: string[];
+  parentFeedbackItemId?: string;
   associatedActionItemIds?: number[];
   columnId: string;
   upvotes: number;
@@ -47,4 +48,5 @@ export interface IFeedbackItemDocument {
   createdDate: Date;
   modifedDate?: Date;
   modifiedBy?: IdentityRef;
+  userIdRef: string;
 }

--- a/Extension/src/Retrospective.Hub.Extension/vss-extension-dev.json
+++ b/Extension/src/Retrospective.Hub.Extension/vss-extension-dev.json
@@ -37,7 +37,7 @@
     "retrospective"
   ],
   "categories": [
-    "Plan and track"
+    "Azure Boards"
   ],
   "scopes": [
     "vso.work",


### PR DESCRIPTION
Fixes #4 

This PR adds an extra option during the creation of a retrospective to only show the cards of the other participants after the "Collect" phase. When switching to "Group", "Vote" or "Act" the feedback items are shown. I chose this approach for now as a first improvement and did not yet add a button as discussed in the issue. This can be added/improved later on.

**Remarks:**
- I could not test this with live syncing as I get the following message: `We are unable to connect to the live syncing service. You can continue to create and edit items as usual, but changes will not be updated in real-time to or from other users`. It seems this has something to do with CORS settings on the backend service and I'm not sure how to resolve this.
- Changed the category from "Plan and track" to "Azure Boards" in the dev file because "Plan and track" wasn't supported anymore
- Also fixed linting errors along the way when reading code or changing code according to the tslint settings so there are changes not linked to this feature directly.

