### PR TITLE
Add link to repository to extension metadata

### DIFF
--- a/RetrospectiveExtension.Frontend/vss-extension-dev.json
+++ b/RetrospectiveExtension.Frontend/vss-extension-dev.json
@@ -39,6 +39,13 @@
   "categories": [
     "Azure Boards"
   ],
+  "repository": {
+    "type": "git",
+    "uri": "https://github.com/microsoft/vsts-extension-retrospectives"
+  },
+  "CustomerQnASupport": {
+    "enableqna":"true"
+  },
   "scopes": [
     "vso.work",
     "vso.work_write"

--- a/RetrospectiveExtension.Frontend/vss-extension-prod.json
+++ b/RetrospectiveExtension.Frontend/vss-extension-prod.json
@@ -39,6 +39,13 @@
   "categories": [
     "Azure Boards"
   ],
+  "repository": {
+    "type": "git",
+    "uri": "https://github.com/microsoft/vsts-extension-retrospectives"
+  },
+  "CustomerQnASupport": {
+    "enableqna":"true"
+  }, 
   "scopes": [
     "vso.work",
     "vso.work_write"


### PR DESCRIPTION
Add link to repository to extension metadata to improve discoverability of source code.

By default Q & A section would redirect to GitHub issues if a GitHub repository link is available. Since there's already an existing Q & A section I disabled this feature to keep the existing entries. 