### PR TITLE
restrict unvote to only your votes

### DIFF
--- a/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
@@ -83,6 +83,7 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
       createdDate: new Date(Date.now()),
       id: 'emptyFeedbackItem',
       title: '',
+      voteCollection: {},
       upvotes: 0,
       userIdRef: userIdentity.id,
     };

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -395,7 +395,7 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
   ];
 
   private onVote = async (feedbackItemId: string,  decrement: boolean=false) => {
-    const updatedFeedbackItem = await itemDataService.updateVote(this.props.boardId, feedbackItemId, decrement);
+    const updatedFeedbackItem = await itemDataService.updateVote(this.props.boardId, getUserIdentity().id, feedbackItemId, decrement);
     appInsightsClient.trackEvent(TelemetryEvents.FeedbackItemUpvoted);
 
     if (updatedFeedbackItem) {

--- a/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
@@ -22,12 +22,14 @@ class ItemDataService {
       createdDate: new Date(Date.now()),
       id: itemId,
       title,
+      voteCollection: {},
       upvotes: 0,
       userIdRef: userIdentity.id,
     };
 
     const createdItem: IFeedbackItemDocument =
       await ExtensionDataService.createDocument<IFeedbackItemDocument>(boardId, feedbackItem);
+    createdItem.voteCollection = {};
 
     return createdItem;
   }
@@ -124,7 +126,7 @@ class ItemDataService {
   /**
    * Increment/Decrement the vote of the feedback item.
    */
-  public updateVote = async (boardId: string, feedbackItemId: string, decrement: boolean = false): Promise<IFeedbackItemDocument> => {
+  public updateVote = async (boardId: string, userId: string, feedbackItemId: string, decrement: boolean = false): Promise<IFeedbackItemDocument> => {
     const feedbackItem: IFeedbackItemDocument = await this.getFeedbackItem(boardId, feedbackItemId);
 
     if (!feedbackItem) {
@@ -137,9 +139,16 @@ class ItemDataService {
         console.log(`Cannot decrement upvote as votes must be >0 to decrement. Board: ${boardId}, Item: ${feedbackItemId}`);
         return undefined;
       } else {
+        if (feedbackItem.voteCollection[userId] == null || feedbackItem.voteCollection[userId] == 0) {
+          console.log(`Cannot decrement upvote as your votes must be >0 to decrement. Board: ${boardId}, Item: ${feedbackItemId}`);
+          return undefined;
+        }
+        else feedbackItem.voteCollection[userId]--;
         feedbackItem.upvotes--;
       }
     } else {
+      if (feedbackItem.voteCollection[userId] == null) feedbackItem.voteCollection[userId] = 1;
+      else  feedbackItem.voteCollection[userId]++;
       feedbackItem.upvotes++;
     }
 

--- a/RetrospectiveExtension.Frontend/interfaces/feedback.tsx
+++ b/RetrospectiveExtension.Frontend/interfaces/feedback.tsx
@@ -33,6 +33,7 @@ export interface IFeedbackColumn {
   accentColor: string;
 }
 
+
 export interface IFeedbackItemDocument {
   id: string;
   __etag?: number;
@@ -44,6 +45,7 @@ export interface IFeedbackItemDocument {
   associatedActionItemIds?: number[];
   columnId: string;
   upvotes: number;
+  voteCollection : { [voter: string]: number};
   createdBy?: IdentityRef;
   createdDate: Date;
   modifedDate?: Date;


### PR DESCRIPTION
With the initial unvote feature, Engin had pointed out that:
>with this implementation, people can uncast votes that they didn’t cast, so, they can drain already casted votes from other people

These changes should take care of that.