### PR TITLE
Max Votes per User Feature

### DIFF
--- a/RetrospectiveExtension.Frontend/components/feedbackBoard.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoard.tsx
@@ -18,6 +18,8 @@ import { WorkflowPhase } from '../interfaces/workItem';
 
 import FeedbackItemCarousel from './feedbackCarousel';
 import { Dialog, DialogType } from 'office-ui-fabric-react/lib/Dialog';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { getUserIdentity } from '../utilities/userIdentityHelper';
 
 export interface FeedbackBoardProps {
   displayBoard: boolean;
@@ -426,6 +428,13 @@ export default class FeedbackBoard extends React.Component<FeedbackBoardProps, F
 
     return (
       <div className="feedback-board">
+        <div className="feedback-maxvotes-per-user">         
+            <label> {"Max Votes per User: "}</label>
+            <label> {this.props.board.maxvotesPerUser.toString()}</label>
+            <label> {"|  Your Total Votes: "}</label>
+            <label> {this.props.board.boardVoteCollection[getUserIdentity().id]==null? "0" : this.props.board.boardVoteCollection[getUserIdentity().id].toString()}</label>
+        </div>      
+ 
         <div className="feedback-columns-container">
           {this.state.isDataLoaded &&
             feedbackColumnPropsList.map((columnProps) => {

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
@@ -19,7 +19,8 @@ interface IFeedbackBoardMetadataFormProps {
   teamId: string;
   placeholderText: string;
   initialValue: string;
-  onFormSubmit: (title: string, columns: IFeedbackColumn[], isBoardAnonymous: boolean, shouldShowFeedbackAfterCollect: boolean) => void;
+  maxvotesPerUser: number;
+  onFormSubmit: (title: string, maxvotesPerUser: number, columns: IFeedbackColumn[], isBoardAnonymous: boolean, shouldShowFeedbackAfterCollect: boolean ) => void;
   onFormCancel: () => void;
 }
 
@@ -30,12 +31,14 @@ interface IFeedbackBoardMetadataFormState {
   columnCards: IFeedbackColumnCard[];
   isBoardAnonymous: boolean;
   shouldShowFeedbackAfterCollect: boolean;
+  maxvotesPerUser: number;
   isDeleteColumnConfirmationDialogHidden: boolean;
   isChooseColumnIconDialogHidden: boolean;
   isChooseColumnAccentColorDialogHidden: boolean;
   columnCardBeingEdited: IFeedbackColumnCard;
   selectedIconKey: string;
   selectedAccentColorKey: string;
+  boardVoteCollection : { [voter: string]: number};
 }
 
 interface IFeedbackColumnCard {
@@ -80,6 +83,8 @@ export default class FeedbackBoardMetadataForm
       }),
       isBoardAnonymous: this.props.isNewBoardCreation ?
         false : (this.props.currentBoard.isAnonymous ? this.props.currentBoard.isAnonymous : false),
+      maxvotesPerUser: this.props.isNewBoardCreation ?
+      5 : this.props.currentBoard.maxvotesPerUser,
       isBoardNameTaken: false,
       isChooseColumnAccentColorDialogHidden: true,
       isChooseColumnIconDialogHidden: true,
@@ -94,6 +99,7 @@ export default class FeedbackBoardMetadataForm
         this.props.currentBoard.shouldShowFeedbackAfterCollect : false
       ),
       title: this.props.initialValue,
+      boardVoteCollection: {},
     };
   }
 
@@ -126,10 +132,11 @@ export default class FeedbackBoardMetadataForm
     }
 
     this.props.onFormSubmit(
-      this.state.title.trim(),
+      this.state.title.trim(),  this.state.maxvotesPerUser,
       this.state.columnCards.filter((columnCard) => !columnCard.markedForDeletion).map((columnCard) => columnCard.column),
       this.state.isBoardAnonymous,
-      this.state.shouldShowFeedbackAfterCollect);
+      this.state.shouldShowFeedbackAfterCollect,
+     );
   }
 
   private handleIsAnonymousCheckboxChange = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
@@ -143,6 +150,13 @@ export default class FeedbackBoardMetadataForm
       shouldShowFeedbackAfterCollect: checked,
     });
   }
+
+  private handleMaxVotePerUserChange = (ev: ChangeEvent<HTMLInputElement>) => {
+    this.setState({
+      maxvotesPerUser: Number(ev.target.value),
+    });
+  }
+
 
   private showDeleteColumnConfirmationDialog = () => {
     this.setState({
@@ -503,6 +517,15 @@ export default class FeedbackBoardMetadataForm
               }} />
               Note: These selections cannot be modified after board creation.
           </div>
+          <div className="board-metadata-form-section-max-votes">
+            <br></br>
+            <label>Max Votes per User (Current:{this.props.isNewBoardCreation? 5 : this.props.currentBoard.maxvotesPerUser}) :  </label>
+            <input type="number" min="1" max="10" value={this.state.maxvotesPerUser}
+              aria-Label="The maximum total number of votes per user."
+              onChange={this.handleMaxVotePerUserChange}
+            />
+          </div>
+                  
         </div>
         <div className="board-metadata-form-edit-column-section hide-mobile">
           <div className="board-metadata-form-section-header">Columns</div>

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -395,7 +395,7 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
   ];
 
   private onVote = async (feedbackItemId: string,  decrement: boolean=false) => {
-    const updatedFeedbackItem = await itemDataService.updateVote(this.props.boardId, getUserIdentity().id, feedbackItemId, decrement);
+    const updatedFeedbackItem = await itemDataService.updateVote(this.props.boardId, this.props.team.id, getUserIdentity().id, feedbackItemId, decrement);
     appInsightsClient.trackEvent(TelemetryEvents.FeedbackItemUpvoted);
 
     if (updatedFeedbackItem) {

--- a/RetrospectiveExtension.Frontend/dal/boardDataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/boardDataService.tsx
@@ -10,7 +10,7 @@ class BoardDataService {
   public readonly legacyNegativeColumnId: string = 'whatdidntgowell';
 
   public createBoardForTeam = async (
-    teamId: string, title: string, columns: IFeedbackColumn[],
+    teamId: string, title: string, maxxvotesPerUser: number, columns: IFeedbackColumn[],
     isAnonymous?: boolean, shouldShowFeedbackAfterCollect?: boolean, startDate?: Date, endDate?: Date) => {
     const boardId: string = uuid();
     const userIdentity = getUserIdentity();
@@ -25,9 +25,11 @@ class BoardDataService {
       isAnonymous: isAnonymous ? isAnonymous : false,
       modifiedDate: new Date(Date.now()),
       shouldShowFeedbackAfterCollect: shouldShowFeedbackAfterCollect ? shouldShowFeedbackAfterCollect : false,
+      maxvotesPerUser: maxxvotesPerUser,
       startDate,
       teamId,
       title,
+      boardVoteCollection: {},
     }
 
     return await ExtensionDataService.createDocument<IFeedbackBoardDocument>(teamId, board);
@@ -75,7 +77,7 @@ class BoardDataService {
     await ExtensionDataService.deleteDocument(teamId, boardId);
   }
 
-  public updateBoardMetadata = async (teamId: string, boardId: string, title: string, newColumns: IFeedbackColumn[]): Promise<IFeedbackBoardDocument> => {
+  public updateBoardMetadata = async (teamId: string, boardId: string, maxvotesPerUser:number, title: string, newColumns: IFeedbackColumn[]): Promise<IFeedbackBoardDocument> => {
     const board: IFeedbackBoardDocument = await this.getBoardForTeamById(teamId, boardId);
 
     // Check in case board was deleted by other user after option to update was selected by current user
@@ -85,6 +87,7 @@ class BoardDataService {
     }
 
     board.title = title;
+    board.maxvotesPerUser = maxvotesPerUser;
     board.columns = newColumns;
     board.modifiedDate = new Date(Date.now());
 

--- a/RetrospectiveExtension.Frontend/interfaces/feedback.tsx
+++ b/RetrospectiveExtension.Frontend/interfaces/feedback.tsx
@@ -24,6 +24,8 @@ export interface IFeedbackBoardDocument {
   activePhase: WorkflowPhase;
   isAnonymous?: boolean;
   shouldShowFeedbackAfterCollect?: boolean;
+  maxvotesPerUser: number;
+  boardVoteCollection : { [voter: string]: number};
 }
 
 export interface IFeedbackColumn {


### PR DESCRIPTION
Retrospective creator can now set the max vote limit for each user. 

This limit can be changed using the 'Edit Retrospective' dialog but note that the current votes exceeding the new limit will stay on - so use update with caution. This change should ideally be used before voting begins when team collectively thinks that the limit should be different from originally set.  