### PR TITLE
remove unneeded broadcast that's causing issues

### DIFF
--- a/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
@@ -202,7 +202,6 @@ class ItemDataService {
       feedbackItem.upvotes++;
     }
     await this.updateBoardItem(teamId, boardItem);
-    reflectBackendService.broadcastUpdatedBoard(teamId, boardId);
     const updatedFeedbackItem = await this.updateFeedbackItem(boardId, feedbackItem);
     return updatedFeedbackItem;
   }


### PR DESCRIPTION
I have removed the broadcast that was needed and possibly is the cause of the issues we are seeing during the voting process (boards flipping to collect phase)