### PR TITLE
Don't show yourvote-count in Act mode

### DIFF
--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -804,7 +804,7 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
                   </div>
                 }
 
-                {showVotes && this.props.isInteractable && 
+                {showVoteButton && this.props.isInteractable && 
                 
                   <div>
                     <span className="feedback-yourvote-count">[Your Votes: {this.state.userVotes}]</span>


### PR DESCRIPTION
The retro board is often shared on a screen by the moderator when in `Act` mode. Since the moderator can also vote, we don't want to show the `yourvote-count` when in `Act` mode.
This PR changes the visibility of the `yourvote-count` div based on the mode, i.e. only show in `Vote` mode.