### PR TITLE
fix: Use the matching "stop" icon for an item card

### DIFF
--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -849,7 +849,7 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
                  this.timerSwich(this.props.id);
                }}
                >
-              <i className={curTimerState ? "fa fa-stop": "fa fa-play-circle"} />
+              <i className={curTimerState ? "fa fa-stop-circle": "fa fa-play-circle"} />
               <span>  {this.props.timerSecs} (seconds)</span>
              </button> 
              


### PR DESCRIPTION
When an item card does **not** have the timer running, the icon is the
triangular play button, inside of a circle. When the timer is started,
the button's icon is the square "stop" button. However, this is not
contained within a circle. This looks strange by comparison, and looks
like a bug (as it's just a solid-colored box).

Fix this by using the `fa-stop-circle` icon, which matches the existing
`fa-play-circle` button.

Here's what it looks like before this fix:
![image](https://user-images.githubusercontent.com/418560/120374014-49853f00-c319-11eb-8dc9-321e007c5d10.png)

And here's what it looks like after this fix:
![image](https://user-images.githubusercontent.com/418560/120373954-3a05f600-c319-11eb-841d-bbb8c185e68d.png)
