### PR TITLE
Simple fix to a readme file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Clone the repository to your local machine from the Azure DevOps endpoint.
 
 - Using Powershell, navigate to the '/RetrospectiveExtension.Frontend' folder, run `npm install`. This will download all the dependent packages listed in 'package.json'.
 
-- Run `npm run build:p` to build the project. Refer to the 'scripts' section in 'package.json' for other commands.
+- Run `npm run build` to build the project. Refer to the 'scripts' section in 'package.json' for other commands.
 
 - To test your changes, you will need to publish a new extension under a new Azure DevOps publisher account. Refer to the [documentation](https://docs.microsoft.com/en-us/azure/devops/extend/publish/overview?view=vsts) on publishing extensions. You can publish it to any test Azure DevOps organization that you are an admin of (As a Microsoft employee, you can create a new test organization from your Azure DevOps profile page). Currently this is the only way to test the extension.
 


### PR DESCRIPTION
Update `README` to reflect the video you posted. `build:p` does not exist in `packages.json`.

Signed-off-by: arabah <83525683+arabah@users.noreply.github.com>