### PR TITLE
fix: Encode the board URL

### DIFF
--- a/RetrospectiveExtension.Frontend/utilities/boardUrlHelper.tsx
+++ b/RetrospectiveExtension.Frontend/utilities/boardUrlHelper.tsx
@@ -1,9 +1,12 @@
 /// <reference types="vss-web-extension-sdk" />
 
 /**
- * Generates deep link for board.
+ * Generates a URL-safe deep link for board.
+ *
  * @param teamId Id of selected team
  * @param boardId Id of selected board
+ *
+ * @returns the URL-safe (encoded) URL
  */
 export const getBoardUrl = (teamId: string, boardId: string): string => {
   const ctx = VSS.getWebContext();
@@ -15,5 +18,5 @@ export const getBoardUrl = (teamId: string, boardId: string): string => {
 
   const boardDeepLinkUrl = `${ctx.host.uri}${ctx.project.name}/_apps/hub/ms-devlabs.team-retrospectives.home?${queryParams.toString()}`;
 
-  return boardDeepLinkUrl;
+  return encodeURI(boardDeepLinkUrl);
 }


### PR DESCRIPTION
The board URL can contain spaces (the project name is allowed to have
spaces), which results in broken links because the spaces aren't
encoded.

By routing the URL through `encodeURI(..)`, the resulting URL is safe
for consumption by external systems.