### PR TITLE
Add Jest testing to project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,8 @@ RUN apt-get update \
     # Install npm-check-updates tool globally
     && npm install -g npm-check-updates \
     #
+    # Install jest-cli testing framework globally
+    && npm install -g jest-cli \
     # [Optional] Add sudo support for the non-root user
     && apt-get install -y sudo \
     #

--- a/RetrospectiveExtension.Frontend/package.json
+++ b/RetrospectiveExtension.Frontend/package.json
@@ -55,6 +55,7 @@
     "eslint-loader": "4.0.2",
     "eslint-plugin-react": "7.24.0",
     "file-loader": "6.2.0",
+    "jest": "^27.4.7",
     "moment-locales-webpack-plugin": "1.2.0",
     "node-sass": "5.0.0",
     "sass-loader": "10.1.1",


### PR DESCRIPTION
The PR allows the Jest testing framework to be used. Adds the actual testing framework to the list of npm packages, as well as the Jest-CLI tool, which allows additional functionality (i.e. test-watching). Jest-CLI tool added to the Dockerfile, so it is immediately ready for use on container start up.