### PR TITLE
Swap the grouping logic so you have to opt out of moving across columns.

### DIFF
--- a/RetrospectiveExtension.Frontend/components/__mocks__/mocked_components/mockedFeedbackColumn.tsx
+++ b/RetrospectiveExtension.Frontend/components/__mocks__/mocked_components/mockedFeedbackColumn.tsx
@@ -150,7 +150,7 @@ export const testColumnProps = mocked({
   isBoardAnonymous: false,
   shouldFocusOnCreateFeedback: false,
   hideFeedbackItems: false,
-  allowCrossColumnGroups: true,
+  preventCrossColumnGroups: false,
   groupTitles: ['example one', 'example two'],
   isFocusModalHidden: false,
   onVoteCasted: jest.fn(() => { }),

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardContainer.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardContainer.tsx
@@ -81,9 +81,9 @@ export interface FeedbackBoardContainerState {
   isDropIssueInEdgeMessageBarVisible: boolean;
   isDesktop: boolean;
   isAutoResizeEnabled: boolean;
-  allowCrossColumnGroups: boolean;
+  preventCrossColumnGroups: boolean;
   feedbackItems: IFeedbackItemDocument[];
-  contributors: {id: string, name: string, imageUrl: string}[];
+  contributors: { id: string, name: string, imageUrl: string }[];
   effectivenessMeasurementSummary: { questionId: string, question: string, average: number }[];
   effectivenessMeasurementChartData: { questionId: string, red: number, yellow: number, green: number }[];
   teamEffectivenessMeasurementAverageVisibilityClassName: string;
@@ -97,7 +97,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
     super(props);
     this.state = {
       allWorkItemTypes: [],
-      allowCrossColumnGroups: false,
+      preventCrossColumnGroups: false,
       boards: [],
       currentUserId: getUserIdentity().id,
       currentBoard: undefined,
@@ -732,7 +732,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
     isBoardAnonymous: boolean,
     shouldShowFeedbackAfterCollect: boolean,
     displayPrimeDirective: boolean,
-    allowCrossColumnGroups: boolean) => {
+    preventCrossColumnGroups: boolean) => {
     const createdBoard = await BoardDataService.createBoardForTeam(this.state.currentTeam.id,
       title,
       maxvotesPerUser,
@@ -741,7 +741,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       isBoardAnonymous,
       shouldShowFeedbackAfterCollect,
       displayPrimeDirective,
-      allowCrossColumnGroups);
+      preventCrossColumnGroups);
     await this.reloadBoardsForCurrentTeam();
     this.hideBoardCreationDialog();
     reflectBackendService.broadcastNewBoard(this.state.currentTeam.id, createdBoard.id);
@@ -778,13 +778,13 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
     const chartData: { questionId: string, red: number, yellow: number, green: number }[] = [];
 
     [...Array(5).keys()].forEach(e => {
-      chartData.push({ questionId: (e+1).toString(), red: 0, yellow: 0, green: 0 });
+      chartData.push({ questionId: (e + 1).toString(), red: 0, yellow: 0, green: 0 });
     });
 
     this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.forEach(vote => {
       [...Array(5).keys()].forEach(e => {
-        const selection = vote.responses.find(response => response.questionId.toString() === (e+1).toString())?.selection;
-        const data = chartData.find(d => d.questionId === (e+1).toString());
+        const selection = vote.responses.find(response => response.questionId.toString() === (e + 1).toString())?.selection;
+        const data = chartData.find(d => d.questionId === (e + 1).toString());
         if (selection <= 6) {
           data.red++;
         } else if (selection <= 8) {
@@ -900,7 +900,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       isBoardAnonymous: boolean,
       shouldShowFeedbackAfterCollect: boolean,
       displayPrimeDirective: boolean,
-      allowCrossColumnGroups: boolean
+      preventCrossColumnGroups: boolean
     ) => void,
     onCancel: () => void) => {
     return (
@@ -1225,7 +1225,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                                 </thead>
                                 <tbody>
                                   {[...Array(5).keys()].map(e => {
-                                    const questionId = (e+1);
+                                    const questionId = (e + 1);
                                     return (
                                       <EffectivenessMeasurementRow
                                         questionId={questionId}
@@ -1504,32 +1504,34 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
               <div>{this.state.actionItemIds.length} action items created</div>
               <div>Board created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} /> {this.state.currentBoard?.createdBy.displayName}</div>
               <div>
-              Effectiveness Scores ({ this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length } people responded)<br />
+                Effectiveness Scores ({this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length} people responded)<br />
                 <div className="retro-summary-effectiveness-scores">
                   <ul className="chart">
-                  { this.state.effectivenessMeasurementChartData.map((data, index) => { return (
-                      <li key={index}>
-                        <div style={{ width: "200px", color: "#000", textAlign: "end" }}>
-                          { getQuestionShortName(data.questionId) }
-                        </div>
-                        { data.red > 0 &&
-                        <div style={{ backgroundColor: "#d6201f", width: `${((data.red * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%` }} title={getQuestionName(data.questionId)}>
-                          {((data.red * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%
-                        </div>
-                        }
-                        { data.yellow > 0 &&
-                        <div style={{ backgroundColor: "#ffd302", width: `${((data.yellow * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%` }} title={getQuestionName(data.questionId)}>
-                          {((data.yellow * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%
-                        </div>
-                        }
-                        { data.green > 0 &&
-                        <div style={{ backgroundColor: "#006b3d", width: `${((data.green * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%` }} title={getQuestionName(data.questionId)}>
-                          {((data.green * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%
-                        </div>
-                        }
-                      </li>
-                    )})
-                  }
+                    {this.state.effectivenessMeasurementChartData.map((data, index) => {
+                      return (
+                        <li key={index}>
+                          <div style={{ width: "200px", color: "#000", textAlign: "end" }}>
+                            {getQuestionShortName(data.questionId)}
+                          </div>
+                          {data.red > 0 &&
+                            <div style={{ backgroundColor: "#d6201f", width: `${((data.red * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%` }} title={getQuestionName(data.questionId)}>
+                              {((data.red * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%
+                            </div>
+                          }
+                          {data.yellow > 0 &&
+                            <div style={{ backgroundColor: "#ffd302", width: `${((data.yellow * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%` }} title={getQuestionName(data.questionId)}>
+                              {((data.yellow * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%
+                            </div>
+                          }
+                          {data.green > 0 &&
+                            <div style={{ backgroundColor: "#006b3d", width: `${((data.green * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%` }} title={getQuestionName(data.questionId)}>
+                              {((data.green * 100) / this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.length)}%
+                            </div>
+                          }
+                        </li>
+                      )
+                    })
+                    }
                   </ul>
                   <div className="legend">
                     <span>Favorability</span>
@@ -1551,10 +1553,10 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                 </div>
                 <a onClick={() => { this.setState({ teamEffectivenessMeasurementAverageVisibilityClassName: this.state.teamEffectivenessMeasurementAverageVisibilityClassName === "visible" ? "hidden" : "visible" }) }}>Show average points for each question:</a>
                 <div className={this.state.teamEffectivenessMeasurementAverageVisibilityClassName}>
-                { this.state.effectivenessMeasurementSummary.map((measurement, index) => {
+                  {this.state.effectivenessMeasurementSummary.map((measurement, index) => {
                     return <div key={index}><strong>{getQuestionShortName(measurement.questionId)}</strong> - {measurement.question}: {measurement.average}</div>
                   })
-                }
+                  }
                 </div>
               </div>
               {!this.state.currentBoard.isAnonymous ?

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
@@ -30,7 +30,7 @@ interface IFeedbackBoardMetadataFormProps {
     isBoardAnonymous: boolean,
     shouldShowFeedbackAfterCollect: boolean,
     displayPrimeDirective: boolean,
-    allowCrossColumnGroups: boolean) => void;
+    preventCrossColumnGroups: boolean) => void;
   onFormCancel: () => void;
 }
 
@@ -50,7 +50,7 @@ interface IFeedbackBoardMetadataFormState {
   columnCardBeingEdited: IFeedbackColumnCard;
   selectedIconKey: string;
   selectedAccentColorKey: string;
-  allowCrossColumnGroups: boolean;
+  preventCrossColumnGroups: boolean;
 }
 
 interface IFeedbackColumnCard {
@@ -108,8 +108,8 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
         this.props.currentBoard.displayPrimeDirective,
       shouldShowFeedbackAfterCollect: !this.props.isNewBoardCreation &&
         this.props.currentBoard.shouldShowFeedbackAfterCollect,
-      allowCrossColumnGroups: !this.props.isNewBoardCreation &&
-        this.props.currentBoard.allowCrossColumnGroups,
+      preventCrossColumnGroups: !this.props.isNewBoardCreation &&
+        this.props.currentBoard.preventCrossColumnGroups,
       title: this.props.initialValue
     };
   }
@@ -151,7 +151,7 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
       this.state.isBoardAnonymous,
       this.state.shouldShowFeedbackAfterCollect,
       this.state.displayPrimeDirective,
-      this.state.allowCrossColumnGroups
+      this.state.preventCrossColumnGroups
     );
   }
 
@@ -179,9 +179,9 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
     });
   }
 
-  private handleAllowCrossColumnGroups = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
+  private handlePreventCrossColumnGroups = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
     this.setState({
-      allowCrossColumnGroups: checked,
+      preventCrossColumnGroups: checked,
     });
   }
 
@@ -740,12 +740,12 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
 
           <div className="board-metadata-form-section-subheader">
             <Checkbox
-              label="Group feedback across columns"
-              ariaLabel="Group Feedback Across Columns. This selection cannot be modified after board creation."
+              label="Prevent grouping feedback across columns"
+              ariaLabel="Prevent grouping Feedback Across Columns. This selection cannot be modified after board creation."
               boxSide="start"
-              defaultChecked={this.state.allowCrossColumnGroups}
+              defaultChecked={this.state.preventCrossColumnGroups}
               disabled={!this.props.isNewBoardCreation}
-              onChange={this.handleAllowCrossColumnGroups}
+              onChange={this.handlePreventCrossColumnGroups}
             />
           </div>
           <hr></hr>

--- a/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
@@ -125,7 +125,7 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
     const boardItem = await itemDataService.getBoardItem(this.props.team.id, this.props.boardId);
 
     // only drop into another column if that's allowed
-    if (boardItem.allowCrossColumnGroups) {
+    if (!boardItem.preventCrossColumnGroups) {
       await FeedbackColumn.moveFeedbackItem(this.props.refreshFeedbackItems, this.props.boardId, droppedItemId, this.props.columnId);
     }
   }

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -226,10 +226,10 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
     const droppedItemProps = await itemDataService.getFeedbackItem(this.props.boardId, droppedItemId);
 
     const boardItem: IFeedbackBoardDocument = await itemDataService.getBoardItem(this.props.team.id, this.props.boardId);
-    const allowCrossColumnGroups = boardItem.allowCrossColumnGroups;
+    const preventCrossColumnGroups = boardItem.preventCrossColumnGroups;
 
     if (this.props.id !== droppedItemId) {
-      if (allowCrossColumnGroups || this.props.columnId === droppedItemProps.originalColumnId) {
+      if (!preventCrossColumnGroups || this.props.columnId === droppedItemProps.originalColumnId) {
         FeedbackItemHelper.handleDropFeedbackItemOnFeedbackItem(this.props, droppedItemId, this.props.id);
       }
     }

--- a/RetrospectiveExtension.Frontend/dal/boardDataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/boardDataService.tsx
@@ -18,7 +18,7 @@ class BoardDataService {
     isAnonymous?: boolean,
     shouldShowFeedbackAfterCollect?: boolean,
     displayPrimeDirective?: boolean,
-    allowCrossColumnGroups?: boolean,
+    preventCrossColumnGroups?: boolean,
     startDate?: Date,
     endDate?: Date) => {
     const boardId: string = uuid();
@@ -37,7 +37,7 @@ class BoardDataService {
       modifiedDate: new Date(Date.now()),
       shouldShowFeedbackAfterCollect: shouldShowFeedbackAfterCollect ?? false,
       displayPrimeDirective: displayPrimeDirective ?? false,
-      allowCrossColumnGroups: allowCrossColumnGroups ?? false,
+      preventCrossColumnGroups: preventCrossColumnGroups ?? false,
       maxVotesPerUser: maxVotesPerUser,
       startDate,
       teamId,

--- a/RetrospectiveExtension.Frontend/interfaces/feedback.tsx
+++ b/RetrospectiveExtension.Frontend/interfaces/feedback.tsx
@@ -26,7 +26,7 @@ export interface IFeedbackBoardDocument {
   isAnonymous?: boolean;
   shouldShowFeedbackAfterCollect?: boolean;
   displayPrimeDirective?: boolean;
-  allowCrossColumnGroups?: boolean;
+  preventCrossColumnGroups?: boolean;
   maxVotesPerUser: number;
   boardVoteCollection: { [voter: string]: number };
   teamEffectivenessMeasurementVoteCollection: ITeamEffectivenessMeasurementVoteCollection[];
@@ -34,7 +34,7 @@ export interface IFeedbackBoardDocument {
 
 export interface ITeamEffectivenessMeasurementVoteCollection {
   userId: string;
-  responses: {questionId: number, selection: number}[]
+  responses: { questionId: number, selection: number }[]
 }
 
 export interface IFeedbackColumn {


### PR DESCRIPTION
As to not break any old boards, now you have to opt into keeping grouping within columns. You're still able to see the original column something written into when it moves across columns, grouped or not!