### PR TITLE
Update strings and README for anonymous feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ button and then clicking on 'Create new board'.
     Please enter the appropriate information:
 
     - **Retrospective Title**: Enter appropriate text
-    - **Make all feedback anonymous**: When you select this checkbox, user identities for the item
+    - **Do not display names in feedback**: When you select this checkbox, user names for the item
         reators will not be displayed.
     - **Only show feedback after Collect phase**: When selected, users cannot see other users input
         until they have moved to another phase. Other users' feedback will be blurred.

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
@@ -851,8 +851,8 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
 
           <div className="board-metadata-form-section-subheader">
             <Checkbox
-              label="Make all feedback anonymous"
-              ariaLabel="Make all feedback anonymous. This selection cannot be modified after board creation."
+              label="Do not display names in feedback"
+              ariaLabel="Do not display names in feedback. This selection cannot be modified after board creation."
               boxSide="start"
               defaultChecked={this.state.isBoardAnonymous}
               disabled={!this.props.isNewBoardCreation}


### PR DESCRIPTION
#410 - Renames the `Make all feedback anonymous` option to `Do not display names in feedback`

