### PR TITLE
Fix for losing votes when deleting feedback item

### DIFF
--- a/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
@@ -93,13 +93,8 @@ class ItemDataService {
     let updatedChildFeedbackItems: IFeedbackItemDocument[] = [];
 
     const feedbackItem: IFeedbackItemDocument = await readDocument<IFeedbackItemDocument>(boardId, feedbackItemId);
-    if (feedbackItem && feedbackItem.upvotes > 0) {
-      console.log(`Cannot delete a feedback item which has upvotes. Board: ${boardId} Item: ${feedbackItemId}`);
-      return undefined;
-    }
-
-    if(feedbackItem && feedbackItem.upvotes > 0) {
-      console.log(`Cannot delete a feedback item which has upvotes. Board: ${boardId} Item: ${feedbackItemId}`);
+    if (feedbackItem && feedbackItem.voteCollection.keys > 0) {
+      console.log(`Cannot delete a feedback item which has any votes. Board: ${boardId} Item: ${feedbackItemId}`);
       return undefined;
     }
 


### PR DESCRIPTION
Have delete feedback item check for any votes in vote collection not just net votes to ensure downvotes for users aren't lost.


Fix for issue #334:
https://github.com/microsoft/vsts-extension-retrospectives/issues/334

Contribution from @Willowinc Hackathon.