### PR TITLE
fix: Grouped Items are Unreadable in Dark Mode #420

### DIFF
--- a/RetrospectiveExtension.Frontend/css/feedbackItemGroup.scss
+++ b/RetrospectiveExtension.Frontend/css/feedbackItemGroup.scss
@@ -56,6 +56,7 @@
 
         .card-integral-part {
           border-left-width: 3px;
+          background-color: var(--background-color);
         }
       }
     }


### PR DESCRIPTION
Link of issue: https://github.com/microsoft/vsts-extension-retrospectives/issues/420

Basically on card-integral-part are missing the global variable of Azure DevOps theme background.
![image](https://user-images.githubusercontent.com/54694777/188461060-322330d7-a5ec-42a3-8af4-ff193f9a424c.png)
