### PR TITLE
fix: Restore "..." for menu button

### DIFF
--- a/RetrospectiveExtension.Frontend/components/feedbackBoardContainer.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardContainer.tsx
@@ -1208,7 +1208,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                             items: this.boardActionContexualMenuItems,
                           }}
                         >
-                          <span className="ms-Button-icon"><i className="fa-solid fa-grip"></i></span>&nbsp;
+                          <span className="ms-Button-icon"><i className="fa-solid fa-ellipsis-h"></i></span>&nbsp;
                         </DefaultButton>
                         <Dialog
                           hidden={this.state.isMobileBoardActionsDialogHidden}


### PR DESCRIPTION
The menu iconography was changed in #422 from `...` to `:::`.
However, `:::` is generally used for a drag handle in a drag-and-drop
UI, rather than an overflow menu.