### PR TITLE
Change deploy script references from .NET 5 to .NET 6

### DIFF
--- a/RetrospectiveExtension.Backend/deploy/env_setup.sh
+++ b/RetrospectiveExtension.Backend/deploy/env_setup.sh
@@ -103,7 +103,7 @@
         --name "app-${resource_name_suffix}" \
         --resource-group "$resource_group" \
         --plan "plan-${resource_name_suffix}"\
-        --runtime "DOTNET|5.0"
+        --runtime "DOTNET|6.0"
 
     signalr_connection_string=$( \
         az signalr key list \
@@ -144,7 +144,7 @@
     # Publish the Dotnet project
     dotnet publish -c Release
 
-    cd  bin/Release/net5/publish/
+    cd  bin/Release/net6.0/publish/
     # Zip the deployed artifact
     zip -r "../../../website.zip" .
 


### PR DESCRIPTION
# Pull Request
#486 

## Description
Change deploy script references from .NET 5 to .NET 6.

## Bug or Feature?

- [x] Bug fix
- [ ] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly.
- [ ] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`,
    to be included with the next release.
  - [ ] I have included a link to this PR in that blurb.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

<!-- Do you have any screenshots or logs that would show off your fix? -->
