### PR TITLE
When creating new retrospective hub, checkbox do not have a visual effect #526

### DIFF
--- a/RetrospectiveExtension.Frontend/css/feedbackBoardMetadataForm.scss
+++ b/RetrospectiveExtension.Frontend/css/feedbackBoardMetadataForm.scss
@@ -322,3 +322,7 @@ $feedback_column_card_height: 60px;
     color: var(--text-primary-color);
   }
 }
+
+.ms-Checkbox:not(.is-checked):hover .ms-Checkbox-checkmark{
+  display:none;
+}


### PR DESCRIPTION
When creating new retrospective hub, checkbox do not have a visual effect

# Pull Request

Relevant Issue(s): #526 

## Description

Removing display where ms-Checkbox is checked

## Bug or Feature?

- [X] Bug fix
- [ ] New feature

## Fundamentals

- [X] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated any relevant documentation accordingly.
- [ ] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`,
    to be included with the next release.
  - [ ] I have included a link to this PR in that blurb.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Accessibility

- [X] I have tested my changes on both light and dark themes.
- [X] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

Hover when false:
![image](https://user-images.githubusercontent.com/54694777/229537623-46f755e7-cd14-4c79-8e8c-2fbe6a65f4d8.png)

Hover when true:
![image](https://user-images.githubusercontent.com/54694777/229537643-dc18db04-67e0-44c4-9040-71123801c6d1.png)

