### PR TITLE
#466: Team Assessment Form Color Gradient to Match Summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ You can find the changelog of the Retrospective Extension below.
 
 _PS: Unfortunately, changelog before v1.0.46 is not available_ 🤦‍♂️
 
+## v1.XX.XX
+
+* Team Assessment form: Background colors for each number on the spectrum now more
+closely resemble the Retrospective summary's color separation for the three categories:
+Reds and Oranges for Unfavorable (1-6), Yellows for Neutral (7-8), Greens for
+Favorable (9-10). From [Github PR #531](https://github.com/microsoft/vsts-extension-retrospectives/pull/531).
+
 ## v1.90.3
 
 * Github Experience: Updating README to include the code coverage and status badges. Github PRs now get code coverage comments from CodeCov. From [Github PR #461](https://github.com/microsoft/vsts-extension-retrospectives/pull/461).

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardContainer.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardContainer.tsx
@@ -1189,24 +1189,24 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             }}>
             <DialogFooter>
               <PrimaryButton onClick={async () => {
-                    const question = questions.filter((question) => question.id === this.state.questionIdForDiscussAndActBoardUpdate)[0];
-                    const templateName = question.discussActTemplate;
-                    const columns = getColumnsByTemplateId(templateName);
+                const question = questions.filter((question) => question.id === this.state.questionIdForDiscussAndActBoardUpdate)[0];
+                const templateName = question.discussActTemplate;
+                const columns = getColumnsByTemplateId(templateName);
 
-                    const board = this.state.currentBoard;
-                    const columnId = columns[0].id;
+                const board = this.state.currentBoard;
+                const columnId = columns[0].id;
 
-                    await this.updateBoardMetadata(board.title, board.maxVotesPerUser, columns);
+                await this.updateBoardMetadata(board.title, board.maxVotesPerUser, columns);
 
-                    /*
-                    TODO (enpolat) : in the future we may need to create feedback items based on the answers of the questions
-                    this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.flatMap(e => e.responses).filter(e => e.questionId === question.id).forEach(async vote => {
-                      const item = await itemDataService.createItemForBoard(board.id, vote.selection.toString(), columnId, true);
-                      reflectBackendService.broadcastNewItem(columnId, item.id);
-                    });
-                    */
+                /*
+                TODO (enpolat) : in the future we may need to create feedback items based on the answers of the questions
+                this.state.currentBoard.teamEffectivenessMeasurementVoteCollection.flatMap(e => e.responses).filter(e => e.questionId === question.id).forEach(async vote => {
+                  const item = await itemDataService.createItemForBoard(board.id, vote.selection.toString(), columnId, true);
+                  reflectBackendService.broadcastNewItem(columnId, item.id);
+                });
+                */
 
-                    this.setState({ questionIdForDiscussAndActBoardUpdate: -1, isRetroSummaryDialogHidden: true });
+                this.setState({ questionIdForDiscussAndActBoardUpdate: -1, isRetroSummaryDialogHidden: true });
               }} text="Proceed" />
               <DefaultButton onClick={() => this.setState({ questionIdForDiscussAndActBoardUpdate: -1 })} text="Cancel" />
             </DialogFooter>
@@ -1294,7 +1294,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                       </div>
                     </div>
                     <div className="feedback-workflow-wrapper">
-                    {this.state.currentBoard.displayPrimeDirective &&
+                      {this.state.currentBoard.displayPrimeDirective &&
                         <div className="prime-directive-dialog-section">
                           <Dialog
                             hidden={this.state.isPrimeDirectiveDialogHidden}
@@ -1369,16 +1369,16 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                                   <tr>
                                     <th></th>
                                     <th></th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#F8696B" }}>1</th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#F98570" }}>2</th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#FBA276" }}>3</th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#FCBF7B" }}>4</th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#FEDC81" }}>5</th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#EEE683" }}>6</th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#CCDD82" }}>7</th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#A9D27F" }}>8</th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#86C97E" }}>9</th>
-                                    <th className="voting-measurement-index" style={{ backgroundColor: "#63BE7B" }}>10</th>
+                                    <th className="voting-measurement-index voting-measurement-index-unfavorable voting-index-1">1</th>
+                                    <th className="voting-measurement-index voting-measurement-index-unfavorable voting-index-2">2</th>
+                                    <th className="voting-measurement-index voting-measurement-index-unfavorable voting-index-3">3</th>
+                                    <th className="voting-measurement-index voting-measurement-index-unfavorable voting-index-4">4</th>
+                                    <th className="voting-measurement-index voting-measurement-index-unfavorable voting-index-5">5</th>
+                                    <th className="voting-measurement-index voting-measurement-index-unfavorable voting-index-6">6</th>
+                                    <th className="voting-measurement-index voting-measurement-index-neutral voting-index-7">7</th>
+                                    <th className="voting-measurement-index voting-measurement-index-neutral voting-index-8">8</th>
+                                    <th className="voting-measurement-index voting-measurement-index-favorable voting-index-9">9</th>
+                                    <th className="voting-measurement-index voting-measurement-index-favorable voting-index-10">10</th>
                                   </tr>
                                 </thead>
                                 <tbody>
@@ -1410,9 +1410,9 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                             calloutProps={{ gapSpace: 0 }}>
                             <ActionButton
                               className="toggle-carousel-button"
+                              iconProps={{ iconName: 'Chart' }}
+                              text="Team Assessment"
                               onClick={() => { this.setState({ isIncludeTeamEffectivenessMeasurementDialogHidden: false }); }}>
-                              <span className="ms-Button-icon"><i className="fas fa-chart-line"></i></span>&nbsp;
-                              <span className="ms-Button-label">Team Assessment</span>
                             </ActionButton>
                           </TooltipHost>
                         </div>

--- a/RetrospectiveExtension.Frontend/css/feedbackBoardContainer.scss
+++ b/RetrospectiveExtension.Frontend/css/feedbackBoardContainer.scss
@@ -303,9 +303,74 @@ $team_selector_list_item_width: 450px;
     }
 
     .voting-measurement-index {
-      color: var(--background-color);
-    }
+      color: #ffffff;
 
+      &.voting-measurement-index-unfavorable {
+        text-shadow: -1px 0 #a61919, 0 1px #a61919, 1px 0 #a61919, 0 -1px #a61919;
+
+        &.voting-index-1 {
+          background-color: rgb(219, 77, 79);
+          background-image: repeating-linear-gradient(45deg, transparent, transparent 9px, #bd1c1a 9px, #bd1c1a 10px);
+        }
+
+        &.voting-index-2 {
+          background-color: rgb(225, 102, 79);
+          background-image: repeating-linear-gradient(45deg, transparent, transparent 9px, #cc4127 9px, #cc4127 10px);
+        }
+
+        &.voting-index-3 {
+          background-color: rgb(238, 121, 79);
+          background-image: repeating-linear-gradient(45deg, transparent, transparent 9px, #e15927 9px, #e15927 10px);
+        }
+
+        &.voting-index-4 {
+          background-color: rgb(240, 155, 79);
+          background-image: repeating-linear-gradient(45deg, transparent, transparent 9px, #cc7424 9px, #cc7424 10px);
+        }
+
+        &.voting-index-5 {
+          background-color: rgb(251, 177, 79);
+          background-image: repeating-linear-gradient(45deg, transparent, transparent 9px, #e89c37 9px, #e89c37 10px);
+        }
+
+        &.voting-index-6 {
+          background-color: rgb(253, 193, 79);
+          background-image: repeating-linear-gradient(45deg, transparent, transparent 9px, #df9e24 9px, #df9e24 10px);
+        }
+      }
+
+      &.voting-measurement-index-neutral {
+        text-shadow: -1px 0 #b19500, 0 1px #b19500, 1px 0 #b19500, 0 -1px #b19500;
+
+        &.voting-index-7 {
+          background-color: rgb(255, 211, 92);
+          background-image: repeating-linear-gradient(90deg, transparent, transparent 7px, #ecc503 7px, #ecc503 8px);
+        }
+
+        &.voting-index-8 {
+          background-color: rgb(242, 227, 92);
+          background-image: repeating-linear-gradient(90deg, transparent, transparent 7px, #f7d113 7px, #f7d113 8px);
+        }
+      }
+
+      &.voting-measurement-index-favorable {
+        text-shadow: -1px 0 #157b00, 0 1px #157b00, 1px 0 #157b00, 0 -1px #157b00;
+
+        &.voting-index-9 {
+          background-color: rgb(141, 223, 126);
+          background-image: radial-gradient(#00a45d 10%, transparent 10%), radial-gradient(#00a45d 10%, transparent 10%);
+          background-size: 12px 12px;
+          background-position: top left, 6px 6px;
+        }
+
+        &.voting-index-10 {
+          background-color: rgb(98, 204, 126);
+          background-image: radial-gradient(#006238 10%, transparent 10%), radial-gradient(#006238 10%, transparent 10%);
+          background-size: 12px 12px;
+          background-position: top left, 6px 6px;
+        }
+      }
+    }
   }
 
   tbody {
@@ -324,7 +389,7 @@ $team_selector_list_item_width: 450px;
       }
 
       .effectivemess-measurement-voting-button {
-        color: $azdo_blue  !important;
+        color: $azdo_blue !important;
       }
 
       .effectiveness-measurement-tooltip-cell {


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #466 

## Description

This PR aligns the colors in the Team Assessment Form to be similar to the three categories in the summary (Unfavorable, Neutral, Favorable).

## Bug or Feature?

- [x] Bug fix
- [ ] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly.
- [x] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`,
    to be included with the next release.
  - [x] I have included a link to this PR in that blurb.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Accessibility

- [x] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [x] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs
Light Theme:
<img width="457" alt="image" src="https://user-images.githubusercontent.com/7254163/235758194-2a020bb6-8dcf-4ac5-a8e2-27ded2a0f16f.png">

Dark Theme:
<img width="451" alt="image" src="https://user-images.githubusercontent.com/7254163/235758106-62d0ce27-4058-492a-8fc7-92ea7dbbd2ae.png">