### PR TITLE
New 'Focus Mode' tab called 'All'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _PS: Unfortunately, changelog before v1.0.46 is not available_ 🤦‍♂️
 closely resemble the Retrospective summary's color separation for the three categories:
 Reds and Oranges for Unfavorable (1-6), Yellows for Neutral (7-8), Greens for
 Favorable (9-10). From [Github PR #531](https://github.com/microsoft/vsts-extension-retrospectives/pull/531).
+* New tab in "Focus Mode", called "All", which contains every card on the current retrospective board so that
+your team can prioritize the highest voted cards first.
 
 ## v1.91.1
 

--- a/RetrospectiveExtension.Frontend/components/__tests__/feedbackCarousel.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/feedbackCarousel.test.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import FeedbackCarousel from '../../components/feedbackCarousel';
 import { testColumnProps } from '../__mocks__/mocked_components/mockedFeedbackColumn';
+import { mockUuid } from '../__mocks__/uuid/v4';
 
 const mockedProps = {
   feedbackColumnPropsList: [testColumnProps],
   isFeedbackAnonymous: true,
   isFocusModalHidden: false
 };
+
+jest.mock('uuid', () => ({ v4: () => mockUuid}));
 
 describe('Feedback Carousel ', () => {
   it('can be rendered', () => {
@@ -16,4 +19,24 @@ describe('Feedback Carousel ', () => {
     expect(component.prop('className')).toBe('feedback-carousel-pivot');
     expect(component.findWhere(c => c.prop('headerText') === testColumnProps.columnName)).toHaveLength(1);
   });
+
+  describe("'All' column", () => {
+    it("should be set by default in the first position", () => {
+      const wrapper = shallow(<FeedbackCarousel {...mockedProps} />);
+      const component = wrapper.children().dive();
+  
+      const allColumn = component.findWhere(c => c.prop('headerText')).first();
+  
+      expect(allColumn.prop('headerText')).toEqual('All');
+    });
+
+    it("should not exist when there are no feedback columns", () => {
+      const wrapper = shallow(<FeedbackCarousel feedbackColumnPropsList={[]} isFeedbackAnonymous={true} isFocusModalHidden={false} />);
+      const component = wrapper.children().dive();
+  
+      const allColumn = component.findWhere(c => c.prop('headerText')).first();
+  
+      expect(allColumn).toHaveLength(0);
+    });
+  })
 });

--- a/RetrospectiveExtension.Frontend/components/__tests__/feedbackColumn.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/feedbackColumn.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { testColumnProps } from '../__mocks__/mocked_components/mockedFeedbackColumn';
+import FeedbackColumn from '../feedbackColumn';
+import FeedbackItem from '../feedbackItem';
+import { IColumnItem } from '../feedbackBoard';
+
+describe('Feedback Column ', () => {
+  it('can be rendered', () => {
+    const wrapper = shallow(<FeedbackColumn {...testColumnProps} />);
+    expect(wrapper.prop('className')).toBe('feedback-column');
+  });
+
+  describe('child feedback items', () => {
+
+    testColumnProps.isDataLoaded = true;
+
+    it('can be rendered', () => {
+      const wrapper = shallow(<FeedbackColumn {...testColumnProps} />);
+      const feedbackItemProps = FeedbackColumn.createFeedbackItemProps(testColumnProps, testColumnProps.columnItems[0], true);
+
+      expect(wrapper.containsMatchingElement(<FeedbackItem key={feedbackItemProps.id} {...feedbackItemProps} />)).toEqual(true);
+    });
+
+    it('should render with original accent color when the column ids are the same', () => {
+      const expectedAccentColor: string = testColumnProps.accentColor;
+      const feedbackItemProps = FeedbackColumn.createFeedbackItemProps(testColumnProps, testColumnProps.columnItems[0], true);
+
+      expect(feedbackItemProps.accentColor).toEqual(expectedAccentColor);
+    });
+
+    it('should render with original column accent color when the column ids are different', () => {
+      const columnItem: IColumnItem = testColumnProps.columnItems[0];
+      const expectedAccentColor: string = testColumnProps.columns[columnItem.feedbackItem.originalColumnId]?.columnProperties?.accentColor;
+
+      testColumnProps.accentColor = 'someOtherColor';
+      testColumnProps.columnId = 'some-other-column-uuid';
+
+      const feedbackItemProps = FeedbackColumn.createFeedbackItemProps(testColumnProps, testColumnProps.columnItems[0], true);
+
+      expect(feedbackItemProps.accentColor).toEqual(expectedAccentColor);
+    });
+  })
+
+});

--- a/RetrospectiveExtension.Frontend/components/feedbackCarousel.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackCarousel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { v4 as uuid } from 'uuid';
 import Slider, { Settings } from "react-slick";
 import FeedbackColumn, { FeedbackColumnProps } from './feedbackColumn';
 import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/Pivot';
@@ -8,6 +9,7 @@ import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import { withAITracking } from '@microsoft/applicationinsights-react-js';
 import { reactPlugin } from '../utilities/telemetryClient';
+import { IColumnItem } from './feedbackBoard';
 
 export interface IFeedbackCarouselProps {
   feedbackColumnPropsList: FeedbackColumnProps[];
@@ -71,6 +73,44 @@ class FeedbackCarousel extends React.Component<IFeedbackCarouselProps, IFeedback
 
     // Change this value to adjust what "two lines" is considered
     const childTitleLengthMax = 200;
+
+    // Added an "All" column by default which is a clone of an existing
+    // column configuration, but will contain static "All" column data and
+    // every feedback card. "All" column gets applied in the carousel so
+    // that is does not impact any UI outside of "Focus Mode".
+    if(this.props.feedbackColumnPropsList.length > 0) {
+      const existingColumn: FeedbackColumnProps = this.props.feedbackColumnPropsList[0];
+
+      const allColumnItems: IColumnItem[] = [...this.props.feedbackColumnPropsList.flatMap(c => c.columnItems)];
+      const allColumnId: string = uuid();
+      const allColumnName: string = 'All';
+      const allFeedbackColumn: FeedbackColumnProps = {
+        ...existingColumn,
+        columnId: allColumnId,
+        columnIds: [
+          ...existingColumn.columnIds,
+          allColumnId
+        ],
+        columns: {
+          ...existingColumn.columns,
+          [allColumnId]: {
+            columnItems: allColumnItems,
+            columnProperties: {
+              id: allColumnId,
+              title: allColumnName,
+              iconClass: '',
+              accentColor: ''
+            },
+            shouldFocusOnCreateFeedback: false
+          }
+        },
+        columnItems: allColumnItems,
+        columnName: allColumnName
+      }
+
+      // Always set the "All" column as the first option
+      this.props.feedbackColumnPropsList.unshift(allFeedbackColumn);
+    }
 
     return (
       <Pivot

--- a/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
@@ -152,6 +152,13 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
     columnProps: FeedbackColumnProps,
     columnItem: IColumnItem,
     isInteractable: boolean): IFeedbackItemProps => {
+
+    let accentColor: string = columnProps.accentColor;
+    if(columnItem.feedbackItem.originalColumnId !== columnProps.columnId) {
+      // Ensure that the item's accent color matches the original column's accent color.
+      accentColor = columnProps.columns[columnItem.feedbackItem.originalColumnId]?.columnProperties?.accentColor ?? columnProps.accentColor;
+    }
+
     return {
       id: columnItem.feedbackItem.id,
       title: columnItem.feedbackItem.title,
@@ -163,7 +170,7 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
       timerState: columnItem.feedbackItem.timerstate,
       timerId: columnItem.feedbackItem.timerId,
       workflowPhase: columnProps.workflowPhase,
-      accentColor: columnProps.accentColor,
+      accentColor: accentColor,
       iconClass: columnProps.iconClass,
       createdDate: columnItem.feedbackItem.createdDate.toString(),
       team: columnProps.team,


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #359 

## Description

This PR provides a new tab in "Focus Mode", called "All", which lists every retrospective card in order by highest votes. This allows teams to prioritize the most voted cards first, without having to toggle between other columns.

## Bug or Feature?

- [ ] Bug fix
- [x] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly.
- [x] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`,
    to be included with the next release.
  - [ ] I have included a link to this PR in that blurb.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [x] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

_'All' tab selected showing a card in the 'Stop' column._
![image](https://github.com/microsoft/vsts-extension-retrospectives/assets/14914689/7e1a9080-158d-4827-af96-d494645b4ca2)

_'All' tab selected showing a card in the 'Continue' column. Notice the accent colors align._
![image](https://github.com/microsoft/vsts-extension-retrospectives/assets/14914689/f2f75c20-eb41-4697-90a8-89f9c5a7ce49)
