### PR TITLE
VSTS retro assessment resources: minor update to 'energy' question

### DIFF
--- a/RetrospectiveExtension.Frontend/utilities/effectivenessMeasurementQuestionHelper.tsx
+++ b/RetrospectiveExtension.Frontend/utilities/effectivenessMeasurementQuestionHelper.tsx
@@ -11,7 +11,7 @@ export const questions = [
     id: 2,
     shortTitle: "Energy",
     discussActTemplate: "energy",
-    title: "I have felt excited to work everyday this past sprint",
+    title: "I am energized by the work I do",
     fontAwesomeClass: "fa-solid fa-bolt",
     tooltip: "Only 2 out of 10 employees strongly indicate that they use their strengths every day at work according to <a target=\"_blank\" rel=\"noreferrer\" href=\"https://www.marcusbuckingham.com/business-case-for-strengths/\">Marcus Buckingham</a>, yet those who do have 38% higher productivity, 44% higher customer satisfaction scores, and 50% higher retention. Using your strengths at work results in being excited to work and is one of the strongest predictors of whether you are on a high performing team. Furthermore, <a target=\"_blank\" rel=\"noreferrer\" href=\"https://www.marcusbuckingham.com/spend-a-week/\">Marcus Buckingham</a> argues that if we spend less than 20% of our time at work doing what we love we are much more likely to burnout. An inspired (excited) employee is 2.25 times more productive than a merely satisfied employee according to research by the <a target=\"_blank\" rel=\"noreferrer\" href=\"https://www.bain.com/insights/summary-of-time-talent-and-energy/#:~:text=Energy%20is%20an%20intangible%20but%20powerful%20force%20that,inspiration%2C%20and%20a%20strong%20company%20culture.%20SUMMARY%20INTRODUCTION?msclkid=e1685e51c7ee11ec88caa816909a51ff\">Bain Company</a> summarized in the book 'Time, Talent, Energy'.",
   },


### PR DESCRIPTION
## Description

This pull request addresses minor grammatical and parallelism issues with a retrospective assessment question by aligning it with the parallel verbiage from Microsoft's "Thriving" bank of questions.

Specific issues:

- 'Energy' inconsistently refers to "this past sprint" when all other questions ask in a period-independent context; the latter is generally preferred for appropriate flexibility in responses
- The use of 'everyday' instead of the phrase 'every day' is an English grammatical error; see resources like this one for more information: https://www.grammarly.com/blog/everyday-every-day/

## Bug or Feature?

- [X] Bug fix
- [ ] New feature

