### PR TITLE
Start Card Numbering at 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ You can find the changelog of the Retrospective Extension below.
 _PS: Unfortunately, changelog before v1.0.46 is not available_ 🤦‍♂️
 
 ## v1.XX.X
+
 * Boards can now restrict access down to specific teams or individuals. From [Github PR #650](https://github.com/microsoft/vsts-extension-retrospectives/pull/650)
+
+* Feedback items are numbered from 1, not 0. From [Github PR #663](https://github.com/microsoft/vsts-extension-retrospectives/pull/663)
 
 ## v1.92.1
 

--- a/RetrospectiveExtension.Frontend/components/__tests__/feedbackItem.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/feedbackItem.test.tsx
@@ -69,9 +69,9 @@ describe('Feedback Item', () => {
 
     expect(component.findWhere((child) =>
       child.prop("className") === "card-id").text()).
-      toEqual(`#${testColumns[testColumnUuidOne].columnItems.findIndex(
+      toEqual(`#${(testColumns[testColumnUuidOne].columnItems.findIndex(
         (columnItem: { feedbackItem: { id: string; }; }) =>
-          columnItem.feedbackItem.id === testFeedbackItem.id)}`);
+          columnItem.feedbackItem.id === testFeedbackItem.id)+1)}`); // +1 because humans start at 1
 
     expect(component.findWhere((child) =>
       child.type() === EditableDocumentCardTitle).prop("title")).

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -847,7 +847,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
                 }
               </div>
               {this.feedbackCreationInformationContent()}
-              <div className="card-id">#{this.props.columns[this.props.columnId].columnItems.findIndex((columnItem) => columnItem.feedbackItem.id === this.props.id)+ 1}</div>
+              <div className="card-id">#{(this.props.columns[this.props.columnId].columnItems.findIndex((columnItem) => columnItem.feedbackItem.id === this.props.id)+1)}</div>
             </div>
             <div className="card-action-item-part">
               {showAddActionItem &&

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -847,7 +847,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
                 }
               </div>
               {this.feedbackCreationInformationContent()}
-              <div className="card-id">#{this.props.columns[this.props.columnId].columnItems.findIndex((columnItem) => columnItem.feedbackItem.id === this.props.id)}</div>
+              <div className="card-id">#{this.props.columns[this.props.columnId].columnItems.findIndex((columnItem) => columnItem.feedbackItem.id === this.props.id)+ 1}</div>
             </div>
             <div className="card-action-item-part">
               {showAddActionItem &&


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): Fixes #521 

## Description

Changes the visual numbering on the cards to start at 1

## Bug or Feature?

- [x] Bug fix
- [ ] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md)
document.
- [x] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly.
- [x] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`,
    to be included with the next release.
  - [x] I have included a link to this PR in that blurb.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

<!-- Do you have any screenshots or logs that would show off your fix? -->
