### PR TITLE
Board permission owner label 

### DIFF
--- a/RetrospectiveExtension.Frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { mockUuid } from '../__mocks__/uuid/v4';
-import FeedbackBoardMetadataForm, { IFeedbackBoardMetadataFormProps, IFeedbackColumnCard } from '../feedbackBoardMetadataForm';
-import { testColumns, testExistingBoard, testTeamId, testUserId } from '../__mocks__/mocked_components/mockedBoardMetadataForm';
-import { Checkbox, List, TextField } from 'office-ui-fabric-react';
+import { testExistingBoard, testTeamId, testUserId } from '../__mocks__/mocked_components/mockedBoardMetadataForm';
+import { TextField } from 'office-ui-fabric-react';
 import FeedbackBoardMetadataFormPermissions, { IFeedbackBoardMetadataFormPermissionsProps } from '../feedbackBoardMetadataFormPermissions';
 
 const mockedProps: IFeedbackBoardMetadataFormPermissionsProps = {
+  board: testExistingBoard,
   permissions: {
     Teams: [],
     Members: []
@@ -227,6 +227,66 @@ describe('Board Metadata Form Permissions', () => {
 
       const last = tableRows.last().find('span').first();
       expect(last.text()).toEqual('Charlie');
+    })
+
+    it('should set an Owner label if the board is created by the user', () => {
+      const props: IFeedbackBoardMetadataFormPermissionsProps = {
+        ...mockedProps,
+        board: {
+          ...mockedProps.board,
+          createdBy: {
+            ...mockedProps.board.createdBy,
+            id: '1'
+          }
+        },
+        permissions: {
+          Teams: [],
+          Members: []
+        },
+        permissionOptions: [
+          {
+            id: '1',
+            name: 'Alpha',
+            uniqueName: 'User 1',
+            type: 'member',
+            thumbnailUrl: ''
+          },
+          {
+            id: '2',
+            name: 'Charlie',
+            uniqueName: 'User 2',
+            type: 'member',
+            thumbnailUrl: ''
+          },
+          {
+            id: '3',
+            name: 'Bravo',
+            uniqueName: 'Team 3',
+            type: 'team',
+            thumbnailUrl: ''
+          },
+          {
+            id: '4',
+            name: 'Zebra',
+            uniqueName: 'Team Z',
+            type: 'team',
+            thumbnailUrl: ''
+          },
+        ]
+      };
+      const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
+      const tableBody = wrapper.find('tbody');
+      const tableRows = tableBody.find('tr');
+
+      expect(tableRows).toHaveLength(4);
+
+      const first = tableRows.first();
+      const hasOwnerLabel1 = first.find('span').last().text() === 'Owner';
+      expect(hasOwnerLabel1).toBeTruthy();
+
+      const last = tableRows.last();
+      const hasOwnerLabel2 = last.find('span').last().text() === 'Owner';
+      expect(hasOwnerLabel2).toBeFalsy();
     })
   });
 });

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
@@ -681,6 +681,7 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
           </PivotItem>
           <PivotItem headerText={'Permissions'} aria-label="Board Permission Settings">
             <FeedbackBoardMetadataFormPermissions
+              board={this.props.currentBoard}
               permissions={this.state.permissions}
               permissionOptions={this.props.availablePermissionOptions}
               onPermissionChanged={(s: FeedbackBoardPermissionState) => this.setState({ permissions: s.permissions })}

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { IFeedbackBoardDocument, IFeedbackBoardDocumentPermissions } from '../interfaces/feedback';
-
 import { withAITracking } from '@microsoft/applicationinsights-react-js';
 import { reactPlugin } from '../utilities/telemetryClient';
 
@@ -197,7 +196,7 @@ function FeedbackBoardMetadataFormPermissions(props: IFeedbackBoardMetadataFormP
                       <span aria-label="Team or member unique name" className="content-sub-text">{option.uniqueName}</span>
                     </div>
                     <div className="content-badge">
-                      {isBoardOwner && <span className="badge badge--owner" aria-label="Board owner badge">{'Owner'}</span>}
+                      {isBoardOwner && <span aria-label="Board owner badge">{'Owner'}</span>}
                     </div>
                   </td>
                 </tr>

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect } from 'react';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { IFeedbackBoardDocumentPermissions } from '../interfaces/feedback';
+import { IFeedbackBoardDocument, IFeedbackBoardDocumentPermissions } from '../interfaces/feedback';
 
 import { withAITracking } from '@microsoft/applicationinsights-react-js';
 import { reactPlugin } from '../utilities/telemetryClient';
 
 export interface IFeedbackBoardMetadataFormPermissionsProps {
+  board: IFeedbackBoardDocument;
   permissions: IFeedbackBoardDocumentPermissions;
   permissionOptions: FeedbackBoardPermissionOption[];
   onPermissionChanged: (state: FeedbackBoardPermissionState) => void;
@@ -173,6 +174,7 @@ function FeedbackBoardMetadataFormPermissions(props: IFeedbackBoardMetadataFormP
           </thead>
           <tbody>
             {filteredPermissionOptions.map((option, index) => {
+              const isBoardOwner: boolean = option.id === props.board.createdBy?.id;
               return (
                 <tr key={'table-row-' + index} className="option-row">
                   <td>
@@ -181,7 +183,8 @@ function FeedbackBoardMetadataFormPermissions(props: IFeedbackBoardMetadataFormP
                       id={"permission-option-" + index}
                       ariaLabel="Add permission to every team or member in the table"
                       boxSide="start"
-                      checked={teamPermissions.includes(option.id) || memberPermissions.includes(option.id)}
+                      disabled={isBoardOwner}
+                      checked={isBoardOwner || teamPermissions.includes(option.id) || memberPermissions.includes(option.id)}
                       onChange={(_, isChecked) => handlePermissionClicked(option, isChecked)}
                     />
                   </td>
@@ -192,6 +195,9 @@ function FeedbackBoardMetadataFormPermissions(props: IFeedbackBoardMetadataFormP
                     <div className="content-text flex flex-col flex-nowrap text-left">
                       <span aria-label="Team or member name">{option.name}</span>
                       <span aria-label="Team or member unique name" className="content-sub-text">{option.uniqueName}</span>
+                    </div>
+                    <div className="content-badge">
+                      {isBoardOwner && <span className="badge badge--owner" aria-label="Board owner badge">{'Owner'}</span>}
                     </div>
                   </td>
                 </tr>

--- a/RetrospectiveExtension.Frontend/css/feedbackBoardMetadataFormPermissions.scss
+++ b/RetrospectiveExtension.Frontend/css/feedbackBoardMetadataFormPermissions.scss
@@ -78,6 +78,21 @@ $content-padding: 10px;
                 color: var(--text-secondary-color);
               }
             }
+
+            .content-badge {
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              margin-left: auto;
+
+              span {
+                background-color: var(--palette-black-alpha-6);
+                padding: 0.125rem 0.5rem;
+                border-radius: 120px;
+                color: var(--text-primary-color);
+                white-space: nowrap;
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #650 

## Description

Improved the UI for board permissions to display the current board owner to help reduce confusion on why users can still see a board. Owners/Creators of boards cannot be removed.

## Bug or Feature?

- [ ] Bug fix
- [x] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md)
document.
- [x] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly.
- [x] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`,
    to be included with the next release.
  - [x] I have included a link to this PR in that blurb.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [x] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.


## Screenshots and Logs

![Screenshot 2024-02-10 at 9 05 18 AM](https://github.com/microsoft/vsts-extension-retrospectives/assets/14914689/5d4f236f-db51-43d2-a05f-e68b1b10853a)

