### PR TITLE
Fixed loading issue for boards

### DIFF
--- a/RetrospectiveExtension.Frontend/css/feedbackBoardMetadataFormPermissions.scss
+++ b/RetrospectiveExtension.Frontend/css/feedbackBoardMetadataFormPermissions.scss
@@ -57,10 +57,13 @@ $content-padding: 10px;
             background-color: var(--background-color);
   
             .content-image {
+              display: flex;
               padding-right: $content-padding;
     
               .permission-image {
                 width: 44px;
+                min-width: 44px;
+                max-width: 44px;
                 height: 44px;
                 border-radius: 99999px; // rounded-full
                 display: flex;


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #671 

## Description

Fixed a loading issue that can occur from a race condition with the current state. This ensures we're are trying to load the most recent team and board without relying on the state to be updated for the initial load. Also fixed the image sizing on board permissions.

## Bug or Feature?

- [x] Bug fix
- [ ] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md)
document.
- [x] My code follows the code style of this project.
- [x] I have updated any relevant documentation accordingly.
- [ ] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`,
    to be included with the next release.
  - [ ] I have included a link to this PR in that blurb.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [x] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

N/A
