### PR TITLE
Sets default order for cards using modified date with newest first

### DIFF
--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1758,7 +1758,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
-                <div id="retro-summary-session-date">Session date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
+                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.createdDate)}</div>
                 <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">

--- a/src/frontend/components/feedbackColumn.tsx
+++ b/src/frontend/components/feedbackColumn.tsx
@@ -206,6 +206,12 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
   private readonly renderFeedbackItems = () => {
     let columnItems: IColumnItem[] = this.props.columnItems || [];
 
+    // Order by modified date with newest first by default
+    columnItems = columnItems.sort((item1, item2) => 
+      (new Date(item2.feedbackItem.modifedDate).getTime()) - (new Date(item1.feedbackItem.modifedDate).getTime())
+    );
+
+    // Order by number of votes if Act column, retaining default order by modified date for tied vote counts
     if (this.props.workflowPhase === WorkflowPhase.Act) {
       columnItems = columnItems.sort((item1, item2) => item2.feedbackItem.upvotes - item1.feedbackItem.upvotes);
     }


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #1045 and #520

## Description

Sets default order for cards using modified date with newest first.  Order was previously arbitrary with unpredictable results for user, except for the Act column which ordered by vote count.  The order by vote count is preserved for the Act column.

Note: current modified Date is misspelled modifedDate (missing i before ed); I did not attempt to fix this issue.

## Bug or Feature?

- [ ] Bug fix
- [x ] New feature

## Fundamentals

- [x ] My code follows the code style of this project.  Note: current modified Date is misspelled modifedDate (missing i before ed)
- [ ] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`, to be included with the next release.


## Accessibility

## Screenshots and Logs