### PR TITLE
Orders cards by created date, unless Act column, then orders by votes

### DIFF
--- a/src/frontend/components/feedbackColumn.tsx
+++ b/src/frontend/components/feedbackColumn.tsx
@@ -207,7 +207,7 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
     let columnItems: IColumnItem[] = this.props.columnItems || [];
 
      // Order by modified date with newest first by default
-     columnItems = columnItems.sort((item1, item2) => 
+     columnItems = columnItems.sort((item1, item2) =>
       (new Date(item2.feedbackItem.modifedDate).getTime()) - (new Date(item1.feedbackItem.modifedDate).getTime())
     );
 

--- a/src/frontend/components/feedbackColumn.tsx
+++ b/src/frontend/components/feedbackColumn.tsx
@@ -206,12 +206,12 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
   private readonly renderFeedbackItems = () => {
     let columnItems: IColumnItem[] = this.props.columnItems || [];
 
-     // Order by modified date with newest first by default
+     // Order by created date with newest first by default
      columnItems = columnItems.sort((item1, item2) =>
-      (new Date(item2.feedbackItem.modifedDate).getTime()) - (new Date(item1.feedbackItem.modifedDate).getTime())
+      (new Date(item2.feedbackItem.createdDate).getTime()) - (new Date(item1.feedbackItem.createdDate).getTime())
     );
 
-    // Order by number of votes if Act column, retaining default order by modified date for tied vote counts
+    // Order by number of votes if Act column, retaining default order by created date for tied vote counts
     if (this.props.workflowPhase === WorkflowPhase.Act) {
       columnItems = columnItems.sort((item1, item2) => item2.feedbackItem.upvotes - item1.feedbackItem.upvotes);
     }

--- a/src/frontend/components/feedbackColumn.tsx
+++ b/src/frontend/components/feedbackColumn.tsx
@@ -206,6 +206,12 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
   private readonly renderFeedbackItems = () => {
     let columnItems: IColumnItem[] = this.props.columnItems || [];
 
+     // Order by modified date with newest first by default
+     columnItems = columnItems.sort((item1, item2) => 
+      (new Date(item2.feedbackItem.modifedDate).getTime()) - (new Date(item1.feedbackItem.modifedDate).getTime())
+    );
+
+    // Order by number of votes if Act column, retaining default order by modified date for tied vote counts
     if (this.props.workflowPhase === WorkflowPhase.Act) {
       columnItems = columnItems.sort((item1, item2) => item2.feedbackItem.upvotes - item1.feedbackItem.upvotes);
     }


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #520 and #1045

## Description

Orders cards by created date, except if Act column, then orders by votes, then modified date

## Bug or Feature?

- [ x] New feature

## Fundamentals

## Accessibility

## Screenshots and Logs
