### PR TITLE
Replaces undefined Session Date with Created Date

### DIFF
--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1774,7 +1774,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
-                <div id="retro-summary-session-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
+                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
                 <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1775,7 +1775,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
                 <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
-                <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
+                <div id="retro-summary-created-by">Created by: <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Participant Summary</div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1774,8 +1774,8 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
-                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.createdDate)}</div>
-                <div id="retro-summary-created-by">Created by: <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
+                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard?.createdDate)}</div>
+                <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Participant Summary</div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1774,8 +1774,8 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
-                <div id="retro-summary-session-date">Session date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
-                <div id="retro-summary-created-by">Created by: <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
+                <div id="retro-summary-session-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
+                <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Participant Summary</div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1775,7 +1775,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
                 <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(this.state.currentBoard.createdDate))}</div>
-              <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
+                <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Participant Summary</div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1774,8 +1774,8 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
-                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard?.createdDate)}</div>
-                <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
+                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(this.state.currentBoard.createdDate))}</div>
+              <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Participant Summary</div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1775,7 +1775,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
                 <div id="retro-summary-session-date">Session date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
-                <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
+                <div id="retro-summary-created-by">Created by: <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Participant Summary</div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1774,7 +1774,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
-                <div id="retro-summary-session-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.createdDate)}</div>
+                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.createdDate)}</div>
                 <div id="retro-summary-created-by">Created by: <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1774,8 +1774,8 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
-                <div id="retro-summary-session-date">Session date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
-                <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
+                <div id="retro-summary-session-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.createdDate)}</div>
+                <div id="retro-summary-created-by">Created by: <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Participant Summary</div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1774,8 +1774,8 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
-                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.createdDate)}</div>
-                <div id="retro-summary-created-by">Created by: <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
+                <div id="retro-summary-session-date">Session date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
+                <div id="retro-summary-created-by">Created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Participant Summary</div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1774,7 +1774,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <>
               <section className="retro-summary-section">
                 <div className="retro-summary-section-header">Basic Settings</div>
-                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
+                <div id="retro-summary-created-date">Created date: {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.createdDate)}</div>
                 <div id="retro-summary-created-by">Created by: <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} alt={this.state.currentBoard?.createdBy.displayName} /> {this.state.currentBoard?.createdBy.displayName} </div>
               </section>
               <section className="retro-summary-section">


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #515 and #682

## Description

Replaces undefined session date which defaults to current date with created date for the retrospective summary.  Created date and created by will be displayed instead of current date and created by.

## Bug or Feature?

- [x] Bug fix
- [ ] New feature

## Fundamentals

## Accessibility

