### PR TITLE
Correct allTeams to fetch All Teams not My Teams

### DIFF
--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -612,7 +612,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
   }
 
   private readonly initializeProjectTeams = async (defaultTeam: WebApiTeam) => {
-    const allTeams = await azureDevOpsCoreService.getAllTeams(this.props.projectId, true);
+    const allTeams = await azureDevOpsCoreService.getAllTeams(this.props.projectId, false);
     allTeams.sort((t1, t2) => {
       return t1.name.localeCompare(t2.name, [], { sensitivity: "accent" });
     });


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #914

## Description

Corrects allTeams to return All Teams, not My Teams.

## Bug or Feature?

- [x] Bug fix
- [ ] New feature
