### PR TITLE
Removes redundant reflect-hub tag when adding work item

### DIFF
--- a/src/frontend/components/actionItemDisplay.tsx
+++ b/src/frontend/components/actionItemDisplay.tsx
@@ -74,7 +74,7 @@ class ActionItemDisplay extends React.Component<ActionItemDisplayProps, ActionIt
 
     const workItem = await workItemNavSvc.openNewWorkItem(workItemTypeName, {
       'System.AssignedTo': assignedUser,
-      'Tags': 'feedback;reflect-hub',
+      'Tags': 'feedback',
       'Title': '',
       'Description': `${this.props.feedbackItemTitle}`,
       'priority': 1,


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #540

## Description

Removes redundant "reflect-hub" tag when adding a work item from a retrospective card.  There are two tags: "feedback" and "reflect-hub".  Better to choose just one tag.  The "feedback" tag is more easily interpreted by the user community, than  "reflect-hub" which is a reference to the original development name of the Retrospective extension.  

## Bug or Feature?

- [x] Bug fix
- [ ] New feature
