### PR TITLE
Dphanson all teams

### DIFF
--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -611,30 +611,9 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
     }
   }
 
-  // allTeams was intentionally returning same teams as userTeams, to avoid performance issues.
-  // Since retrospectives should be safe space, no reason to include teams that user is not a member of.
-  //private readonly initializeProjectTeams = async (defaultTeam: WebApiTeam) => {
-  //  const allTeams = await azureDevOpsCoreService.getAllTeams(this.props.projectId, true);
-  //  allTeams.sort((t1, t2) => {
-  //    return t1.name.localeCompare(t2.name, [], { sensitivity: "accent" });
-  //  });
-//
- //   const promises = []
- //   for (const team of allTeams) {
- //     promises.push(azureDevOpsCoreService.getMembers(this.props.projectId, team.id));
- //   }
- //   Promise.all(promises).then((values) => {
- //     const allTeamMembers: TeamMember[] = [];
- //     for (const members of values) {
-  //      allTeamMembers.push(...members);
- //     }
-  //    this.setState({
-  //      allMembers: allTeamMembers,
-  //      projectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
-  //      filteredProjectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
-  //      isAllTeamsLoaded: true,
-  //    });
-  //  });
+  // Removed All Teams 
+  // Retrospectives should be safe space for team members to share feedback.
+  // Therefore, should not have access to other teams' retrospective boards.
   }
 
   /**

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -611,28 +611,30 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
     }
   }
 
-  private readonly initializeProjectTeams = async (defaultTeam: WebApiTeam) => {
-    const allTeams = await azureDevOpsCoreService.getAllTeams(this.props.projectId, true);
-    allTeams.sort((t1, t2) => {
-      return t1.name.localeCompare(t2.name, [], { sensitivity: "accent" });
-    });
-
-    const promises = []
-    for (const team of allTeams) {
-      promises.push(azureDevOpsCoreService.getMembers(this.props.projectId, team.id));
-    }
-    Promise.all(promises).then((values) => {
-      const allTeamMembers: TeamMember[] = [];
-      for (const members of values) {
-        allTeamMembers.push(...members);
-      }
-      this.setState({
-        allMembers: allTeamMembers,
-        projectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
-        filteredProjectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
-        isAllTeamsLoaded: true,
-      });
-    });
+  // allTeams was intentionally returning same teams as userTeams, to avoid performance issues.
+  // Since retrospectives should be safe space, no reason to include teams that user is not a member of.
+  //private readonly initializeProjectTeams = async (defaultTeam: WebApiTeam) => {
+  //  const allTeams = await azureDevOpsCoreService.getAllTeams(this.props.projectId, true);
+  //  allTeams.sort((t1, t2) => {
+  //    return t1.name.localeCompare(t2.name, [], { sensitivity: "accent" });
+  //  });
+//
+ //   const promises = []
+ //   for (const team of allTeams) {
+ //     promises.push(azureDevOpsCoreService.getMembers(this.props.projectId, team.id));
+ //   }
+ //   Promise.all(promises).then((values) => {
+ //     const allTeamMembers: TeamMember[] = [];
+ //     for (const members of values) {
+  //      allTeamMembers.push(...members);
+ //     }
+  //    this.setState({
+  //      allMembers: allTeamMembers,
+  //      projectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
+  //      filteredProjectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
+  //      isAllTeamsLoaded: true,
+  //    });
+  //  });
   }
 
   /**
@@ -1222,11 +1224,9 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
           header: { id: 'My Teams', title: 'My Teams' },
           items: this.state.userTeams,
         },
-        {
-          finishedLoading: this.state.isAllTeamsLoaded,
-          header: { id: 'All Teams', title: 'All Teams' },
-          items: this.state.projectTeams,
-        },
+        // Removed All Teams 
+        // Retrospectives should be safe space for team members to share feedback.
+        // Therefore, should not have access to other teams' retrospective boards.
       ],
     };
 

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -611,7 +611,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
     }
   }
 
-  // Removed All Teams 
+  // Removed All Teams
   // Retrospectives should be safe space for team members to share feedback.
   // Therefore, should not have access to other teams' retrospective boards.
   }
@@ -1203,7 +1203,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
           header: { id: 'My Teams', title: 'My Teams' },
           items: this.state.userTeams,
         },
-        // Removed All Teams 
+        // Removed All Teams
         // Retrospectives should be safe space for team members to share feedback.
         // Therefore, should not have access to other teams' retrospective boards.
       ],


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #1038, #998, #935, #929, #914, #793

## Description

Removed All Teams 
Retrospectives should be safe space for team members to share feedback.
Therefore, should not have access to other teams' retrospective boards.
Currently the code sets All Teams to the equivalent of My Teams.
Better to not leave false impression that displaying All Teams.

## Bug or Feature?

- [x] Bug fix
- [x] New feature
