### PR TITLE
Remove All Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ Navigate to the Azure 'Boards' tab in your account on the left hand navigation. 
 
 ### 2. Pick The Team
 
-You are now on the Retrospectives page. Select your Azure DevOps team from the selector in the header.
+You are now on the Retrospectives page. Select your Azure DevOps team from the selector in the header. Unlike the screenshot below, you will only be able to select from My Teams. 
+
+Retrospectives should be a safe space for team members to share feedback. Therefore, you should not have access to other teams' retrospective boards. All Teams would provide access to see feedback from any team in the project.
+
+If you need to access another team's retrospective board in the project, you will need to be added as a member of that team. 
 
 ![A screenshot of the Retrospective tool's Team dropdown. The selected team is "Backend Team" and the selection is darkened as though the mouse is hovering over.](https://github.com/microsoft/vsts-extension-retrospectives/raw/main/documentation/images/desktop/team-dropdown.png)
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Navigate to the Azure 'Boards' tab in your account on the left hand navigation. 
 
 ### 2. Pick The Team
 
-You are now on the Retrospectives page. Select your Azure DevOps team from the selector in the header. Unlike the screenshot below, you will only be able to select from My Teams. 
+You are now on the Retrospectives page. Select your Azure DevOps team from the selector in the header. Unlike the screenshot below, you will only be able to select from My Teams.
 
 Retrospectives should be a safe space for team members to share feedback. Therefore, you should not have access to other teams' retrospective boards. All Teams would provide access to see feedback from any team in the project.
 
-If you need to access another team's retrospective board in the project, you will need to be added as a member of that team. 
+If you need to access another team's retrospective board in the project, you will need to be added as a member of that team.
 
 ![A screenshot of the Retrospective tool's Team dropdown. The selected team is "Backend Team" and the selection is darkened as though the mouse is hovering over.](https://github.com/microsoft/vsts-extension-retrospectives/raw/main/documentation/images/desktop/team-dropdown.png)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Navigate to the Azure 'Boards' tab in your account on the left hand navigation. 
 
 ### 2. Pick The Team
 
-You are now on the Retrospectives page. Select your Azure DevOps team from the selector in the header. Unlike the screenshot below, you will only be able to select from My Teams.
+You are now on the Retrospectives page. Select your Azure DevOps team from the dropdown in the header. Unlike the screenshot below, you will only be able to select from My Teams.
 
 Retrospectives should be a safe space for team members to share feedback. Therefore, you should not have access to other teams' retrospective boards. All Teams would provide access to see feedback from any team in the project.
 

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -182,7 +182,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       initialCurrentTeam = initializedTeamAndBoardState.currentTeam;
       initialCurrentBoard = initializedTeamAndBoardState.currentBoard;
 
-   //   await this.initializeProjectTeams(initialCurrentTeam);
+      // removed await on initializeProjectTeams since not user allTeams
 
       this.setState({ ...initializedTeamAndBoardState, isTeamDataLoaded: true, });
     } catch (error) {
@@ -610,6 +610,8 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       };
     }
   }
+
+  // Removed initializeProjectTeams since using only My Teams, not All Teams
 
   /**
    * @description Load the last team and board that this user visited, if such records exist.
@@ -1198,11 +1200,9 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
           header: { id: 'My Teams', title: 'My Teams' },
           items: this.state.userTeams,
         },
-//        {
-//          finishedLoading: this.state.isAllTeamsLoaded,
-//          header: { id: 'All Teams', title: 'All Teams' },
-//          items: this.state.projectTeams,
-//        },
+        // Removed All Teams
+        // Retrospectives should be a safe space for team members to share feedback.
+        // Therefore, team members should only have access to My Teams, not All Teams.
       ],
     };
 

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -182,7 +182,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       initialCurrentTeam = initializedTeamAndBoardState.currentTeam;
       initialCurrentBoard = initializedTeamAndBoardState.currentBoard;
 
-      // removed await on initializeProjectTeams since not user allTeams
+      // removed await on initializeProjectTeams since not using allTeams
 
       this.setState({ ...initializedTeamAndBoardState, isTeamDataLoaded: true, });
     } catch (error) {
@@ -1201,8 +1201,8 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
           items: this.state.userTeams,
         },
         // Removed All Teams
-        // Retrospectives should be a safe space for team members to share feedback.
-        // Therefore, team members should only have access to My Teams, not All Teams.
+        // Retrospectives should be safe space for team members to share feedback.
+        // Therefore, should not have access to other teams's retrospective boards.
       ],
     };
 

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -611,17 +611,6 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
     }
   }
 
-  private readonly initializeProjectTeams = async (defaultTeam: WebApiTeam) => {
-    const allTeams = await azureDevOpsCoreService.getMembers(this.props.projectId, defaultTeam.id);
-
-    this.setState({
-      allMembers: allTeamMembers,
-      projectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
-      filteredProjectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
-      isAllTeamsLoaded: true,
-    });
-  }
-
   /**
    * @description Load the last team and board that this user visited, if such records exist.
    * @returns An object to update the state with recently visited or default team and board data.

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -182,7 +182,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       initialCurrentTeam = initializedTeamAndBoardState.currentTeam;
       initialCurrentBoard = initializedTeamAndBoardState.currentBoard;
 
-      await this.initializeProjectTeams(initialCurrentTeam);
+   //   await this.initializeProjectTeams(initialCurrentTeam);
 
       this.setState({ ...initializedTeamAndBoardState, isTeamDataLoaded: true, });
     } catch (error) {

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1222,11 +1222,11 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
           header: { id: 'My Teams', title: 'My Teams' },
           items: this.state.userTeams,
         },
-        {
-          finishedLoading: this.state.isAllTeamsLoaded,
-          header: { id: 'All Teams', title: 'All Teams' },
-          items: this.state.projectTeams,
-        },
+//        {
+//          finishedLoading: this.state.isAllTeamsLoaded,
+//          header: { id: 'All Teams', title: 'All Teams' },
+//          items: this.state.projectTeams,
+//        },
       ],
     };
 

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -612,26 +612,13 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
   }
 
   private readonly initializeProjectTeams = async (defaultTeam: WebApiTeam) => {
-    const allTeams = await azureDevOpsCoreService.getAllTeams(this.props.projectId, true);
-    allTeams.sort((t1, t2) => {
-      return t1.name.localeCompare(t2.name, [], { sensitivity: "accent" });
-    });
+    const allTeams = await azureDevOpsCoreService.getMembers(this.props.projectId, defaultTeam.id);
 
-    const promises = []
-    for (const team of allTeams) {
-      promises.push(azureDevOpsCoreService.getMembers(this.props.projectId, team.id));
-    }
-    Promise.all(promises).then((values) => {
-      const allTeamMembers: TeamMember[] = [];
-      for (const members of values) {
-        allTeamMembers.push(...members);
-      }
-      this.setState({
-        allMembers: allTeamMembers,
-        projectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
-        filteredProjectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
-        isAllTeamsLoaded: true,
-      });
+    this.setState({
+      allMembers: allTeamMembers,
+      projectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
+      filteredProjectTeams: allTeams?.length > 0 ? allTeams : [defaultTeam],
+      isAllTeamsLoaded: true,
     });
   }
 


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #1038, #998, #935, #929, #914, #793

## Description

Removed All Teams
Retrospectives should be safe space for team members to share feedback.
Therefore, should not have access to other teams' retrospective boards.
Currently the code sets All Teams to the equivalent of My Teams.
Better to not leave false impression that displaying All Teams.

## Bug or Feature?

- [x] Bug fix
- [x] New feature
