### PR TITLE
Permission notice changed to alert that boards available to every member in project

### DIFF
--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -33,7 +33,7 @@ describe('Board Metadata Form Permissions', () => {
   });
 
   describe('Public Banner', () => {
-    const publicBannerText: string = 'This board is visible to every member in the organization.';
+    const publicBannerText: string = 'This board is visible to every member in the project.';
 
     it('should show when there are not team or member permissions', () => {
       const wrapper = shallow(<FeedbackBoardMetadataFormPermissions {...mockedProps} />);

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -123,7 +123,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
   const PublicWarningBanner = () => {
     if(teamPermissions.length === 0 && memberPermissions.length === 0) {
       return <div className="board-metadata-form-section-information">
-        <i className="fas fa-exclamation-circle" aria-label="Board is visible to every member in the organization"></i>&nbsp;This board is visible to every member in the organization.
+        <i className="fas fa-exclamation-circle" aria-label="Board is visible to every member in the organization"></i>&nbsp;This board is visible to every member in the project.
       </div>
     }
 


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): none logged

## Description

Changed notice on Permission tab from "every member in organization" to "every member in project".  

## Bug or Feature?

- [x] Bug fix
- [ ] New feature
