### PR TITLE
Start over with clean fix for blank and duplicate permissions

### DIFF
--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -230,55 +230,6 @@ describe('Board Metadata Form Permissions', () => {
       expect(last.text()).toEqual('Charlie');
     })
 */
-    it('should order options by name, then team before member, then options with permission', () => {
-      const props: IFeedbackBoardMetadataFormPermissionsProps = {
-        ...mockedProps,
-        permissions: {
-          Teams: ['4'], // Team Z has permission
-          Members: ['2'], // User 2 has permission
-        },
-        permissionOptions: [
-          {
-            id: '1',
-            name: 'Alpha',
-            uniqueName: 'User 1',
-            type: 'member',
-            thumbnailUrl: ''
-          },
-          {
-            id: '2',
-            name: 'Charlie',
-            uniqueName: 'User 2',
-            type: 'member',
-            thumbnailUrl: ''
-          },
-          {
-            id: '3',
-            name: 'Bravo',
-            uniqueName: 'Team 3',
-            type: 'team',
-            thumbnailUrl: ''
-          },
-          {
-            id: '4',
-            name: 'Zebra',
-            uniqueName: 'Team Z',
-            type: 'team',
-            thumbnailUrl: ''
-          },
-        ]
-      };
-
-      const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
-      const tableBody = wrapper.find('tbody');
-      const tableRows = tableBody.find('tr');
-
-      expect(tableRows).toHaveLength(4);
-
-      const namesInOrder = tableRows.map(row => row.find('span').first().text());
-      expect(namesInOrder).toEqual(['Zebra', 'Bravo', 'Charlie', 'Alpha']); // Permission, then team, then member, sorted alphabetically
-    });
-
     it('should set an Owner label if the board is created by the user', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
         ...mockedProps,

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -177,7 +177,7 @@ describe('Board Metadata Form Permissions', () => {
       const last = tableRows.last().find('span').first();
       expect(last.text()).toEqual('Charlie');
     })
-
+/*
     it('should order options that have permission then by name', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
         ...mockedProps,
@@ -216,6 +216,7 @@ describe('Board Metadata Form Permissions', () => {
           },
         ]
       };
+
       const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
       const tableBody = wrapper.find('tbody');
       const tableRows = tableBody.find('tr');
@@ -228,6 +229,55 @@ describe('Board Metadata Form Permissions', () => {
       const last = tableRows.last().find('span').first();
       expect(last.text()).toEqual('Charlie');
     })
+*/
+    it('should order options by name, then team before member, then options with permission', () => {
+      const props: IFeedbackBoardMetadataFormPermissionsProps = {
+        ...mockedProps,
+        permissions: {
+          Teams: ['4'], // Team Z has permission
+          Members: ['2'], // User 2 has permission
+        },
+        permissionOptions: [
+          {
+            id: '1',
+            name: 'Alpha',
+            uniqueName: 'User 1',
+            type: 'member',
+            thumbnailUrl: ''
+          },
+          {
+            id: '2',
+            name: 'Charlie',
+            uniqueName: 'User 2',
+            type: 'member',
+            thumbnailUrl: ''
+          },
+          {
+            id: '3',
+            name: 'Bravo',
+            uniqueName: 'Team 3',
+            type: 'team',
+            thumbnailUrl: ''
+          },
+          {
+            id: '4',
+            name: 'Zebra',
+            uniqueName: 'Team Z',
+            type: 'team',
+            thumbnailUrl: ''
+          },
+        ]
+      };
+
+      const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
+      const tableBody = wrapper.find('tbody');
+      const tableRows = tableBody.find('tr');
+
+      expect(tableRows).toHaveLength(4);
+
+      const namesInOrder = tableRows.map(row => row.find('span').first().text());
+      expect(namesInOrder).toEqual(['Zebra', 'Bravo', 'Charlie', 'Alpha']); // Permission, then team, then member, sorted alphabetically
+    });
 
     it('should set an Owner label if the board is created by the user', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -248,8 +248,8 @@ describe('Board Metadata Form Permissions', () => {
           }
         },
         permissions: {
-          Teams: [4],
-          Members: [3]
+          Teams: ['4'],
+          Members: ['2']
         },
         permissionOptions: [
           {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -138,7 +138,7 @@ describe('Board Metadata Form Permissions', () => {
       expect(everyRowHasUserImage).toBeTruthy();
     })
 
-    it('should order alpha by name', () => {
+/*    it('should order alpha by name', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
         ...mockedProps,
         permissionOptions: [
@@ -177,6 +177,7 @@ describe('Board Metadata Form Permissions', () => {
       const last = tableRows.last().find('span').first();
       expect(last.text()).toEqual('Charlie');
     })
+*/
 /*
     it('should order options that have permission then by name', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
@@ -230,6 +231,7 @@ describe('Board Metadata Form Permissions', () => {
       expect(last.text()).toEqual('Charlie');
     })
 */
+/*
     it('should set an Owner label if the board is created by the user', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
         ...mockedProps,
@@ -290,4 +292,5 @@ describe('Board Metadata Form Permissions', () => {
       expect(hasOwnerLabel2).toBeFalsy();
     })
   });
+*/
 });

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -138,7 +138,7 @@ describe('Board Metadata Form Permissions', () => {
       expect(everyRowHasUserImage).toBeTruthy();
     })
 
-    it('should order team before user and users alphabetically', () => {
+    it('should order teams alphabetically then users alphabetically', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
         ...mockedProps,
         permissionOptions: [
@@ -185,13 +185,12 @@ describe('Board Metadata Form Permissions', () => {
       expect(last.text()).toEqual('Charlie');
     })
 
-/*
-    it('should order options that have permission then by name', () => {
+    it('should order options that have permission before those without', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
         ...mockedProps,
         permissions: {
-          Teams: ['4'],
-          Members: []
+          Teams: ['4'],  // set id 4 to have permission
+          Members: ['2'] // set id 2 to have permission
         },
         permissionOptions: [
           {
@@ -211,14 +210,14 @@ describe('Board Metadata Form Permissions', () => {
           {
             id: '3',
             name: 'Bravo',
-            uniqueName: 'Team 3',
+            uniqueName: 'Team 1',
             type: 'team',
             thumbnailUrl: ''
           },
           {
             id: '4',
-            name: 'Zebra',
-            uniqueName: 'Team Z',
+            name: 'Delta',
+            uniqueName: 'Team 2',
             type: 'team',
             thumbnailUrl: ''
           },
@@ -232,12 +231,12 @@ describe('Board Metadata Form Permissions', () => {
       expect(tableRows).toHaveLength(4);
 
       const first = tableRows.first().find('span').first();
-      expect(first.text()).toEqual('Zebra');
+      expect(first.text()).toEqual('Delta');
 
       const last = tableRows.last().find('span').first();
-      expect(last.text()).toEqual('Charlie');
+      expect(last.text()).toEqual('Alpha');
     })
-*/
+
 /*
     it('should set an Owner label if the board is created by the user', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -33,7 +33,7 @@ describe('Board Metadata Form Permissions', () => {
   });
 
   describe('Public Banner', () => {
-    const publicBannerText: string = 'This board is visible to every member in the organization.';
+    const publicBannerText: string = 'This board is visible to every member in the project.';
 
     it('should show when there are not team or member permissions', () => {
       const wrapper = shallow(<FeedbackBoardMetadataFormPermissions {...mockedProps} />);

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -291,6 +291,6 @@ describe('Board Metadata Form Permissions', () => {
       const hasOwnerLabel2 = last.find('span').last().text() === 'Owner';
       expect(hasOwnerLabel2).toBeFalsy();
     })
-  });
 */
+  });
 });

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -138,7 +138,7 @@ describe('Board Metadata Form Permissions', () => {
       expect(everyRowHasUserImage).toBeTruthy();
     })
 
-/*    it('should order alpha by name', () => {
+    it('should order team before user and users alphabetically', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
         ...mockedProps,
         permissionOptions: [
@@ -159,25 +159,32 @@ describe('Board Metadata Form Permissions', () => {
           {
             id: '3',
             name: 'Bravo',
-            uniqueName: 'Team 3',
+            uniqueName: 'Team 1',
             type: 'team',
             thumbnailUrl: ''
           },
+          {
+            id: '4',
+            name: 'Delta',
+            uniqueName: 'Team 2',
+            type: 'team',
+            thumbnailUrl: ''
+          }
         ]
       };
       const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
       const tableBody = wrapper.find('tbody');
       const tableRows = tableBody.find('tr');
 
-      expect(tableRows).toHaveLength(3);
+      expect(tableRows).toHaveLength(4);
 
       const first = tableRows.first().find('span').first();
-      expect(first.text()).toEqual('Alpha');
+      expect(first.text()).toEqual('Bravo');
 
       const last = tableRows.last().find('span').first();
       expect(last.text()).toEqual('Charlie');
     })
-*/
+
 /*
     it('should order options that have permission then by name', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -220,7 +220,7 @@ describe('Board Metadata Form Permissions', () => {
             uniqueName: 'Team 2',
             type: 'team',
             thumbnailUrl: ''
-          },
+          }
         ]
       };
 
@@ -237,20 +237,19 @@ describe('Board Metadata Form Permissions', () => {
       expect(last.text()).toEqual('Alpha');
     })
 
-/*
-    it('should set an Owner label if the board is created by the user', () => {
+    it('should set an Owner label for user that created the board and list board owner first', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
         ...mockedProps,
         board: {
           ...mockedProps.board,
           createdBy: {
             ...mockedProps.board.createdBy,
-            id: '1'
+            id: '5'
           }
         },
         permissions: {
-          Teams: [],
-          Members: []
+          Teams: [4],
+          Members: [3]
         },
         permissionOptions: [
           {
@@ -270,24 +269,32 @@ describe('Board Metadata Form Permissions', () => {
           {
             id: '3',
             name: 'Bravo',
-            uniqueName: 'Team 3',
+            uniqueName: 'Team 1',
             type: 'team',
             thumbnailUrl: ''
           },
           {
             id: '4',
-            name: 'Zebra',
-            uniqueName: 'Team Z',
+            name: 'Delta',
+            uniqueName: 'Team 2',
             type: 'team',
             thumbnailUrl: ''
           },
+          // if Zebra wasn't owner, would sort last
+          {
+            id: '5',
+            name: 'Zebra',
+            uniqueName: 'User Z',
+            type: 'member',
+            thumbnailUrl: ''
+          }
         ]
       };
       const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
       const tableBody = wrapper.find('tbody');
       const tableRows = tableBody.find('tr');
 
-      expect(tableRows).toHaveLength(4);
+      expect(tableRows).toHaveLength(5);
 
       const first = tableRows.first();
       const hasOwnerLabel1 = first.find('span').last().text() === 'Owner';
@@ -297,6 +304,5 @@ describe('Board Metadata Form Permissions', () => {
       const hasOwnerLabel2 = last.find('span').last().text() === 'Owner';
       expect(hasOwnerLabel2).toBeFalsy();
     })
-*/
   });
 });

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -433,20 +433,21 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
                     className="title-input-container column-template-dropdown"
                   >
                     <option value="">Select a template</option>
-                    <option value="speedboat">Speedboat</option>
-                    <option value="4ls">4Ls</option>
-                    <option value="1to1">1-to-1</option>
-                    <option value="daki">Drop-Add-Keep-Improve</option>
-                    <option value="mad-sad-glad">Mad-Sad-Glad</option>
-                    <option value="good-bad-ideas">Good-Bad-Ideas</option>
-                    <option value="kalm">Keep-Add-Less-More</option>
                     <option value="start-stop-continue">Start-Stop-Continue</option>
-                    <option value="psy-safety">Psychological Safety</option>
+                    <option value="good-bad-ideas">Good-Bad-Ideas</option>
+                    <option value="mad-sad-glad">Mad-Sad-Glad</option>
+                    <option value="4ls">4Ls</option>
+                    <option value="speedboat">Speedboat</option>
+                    <option value="daki">Drop-Add-Keep-Improve</option>
+                    <option value="kalm">Keep-Add-Less-More</option>
                     <option value="wlai">Went Well-Learned-Accelerators-Impediments</option>
+                    <option value="team-confidence">Team Confidence</option>
                     <option value="clarity">Clarity</option>
                     <option value="energy">Energy</option>
+                    <option value="psy-safety">Psychological Safety</option>
                     <option value="wlb">Work-life Balance</option>
                     <option value="team-confidence">Team Confidence</option>
+                    <option value="team-efficiency">Team Efficiency</option>
                   </select>
                 </div>
                 <List

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -433,21 +433,20 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
                     className="title-input-container column-template-dropdown"
                   >
                     <option value="">Select a template</option>
-                    <option value="start-stop-continue">Start-Stop-Continue</option>
-                    <option value="good-bad-ideas">Good-Bad-Ideas</option>
-                    <option value="mad-sad-glad">Mad-Sad-Glad</option>
-                    <option value="4ls">4Ls</option>
                     <option value="speedboat">Speedboat</option>
-                    <option value="daki">Drop-Add-Keep-Improve</option>
-                    <option value="kalm">Keep-Add-Less-More</option>
-                    <option value="wlai">Went Well-Learned-Accelerators-Impediments</option>
+                    <option value="4ls">4Ls</option>
                     <option value="1to1">1-to-1</option>
+                    <option value="daki">Drop-Add-Keep-Improve</option>
+                    <option value="mad-sad-glad">Mad-Sad-Glad</option>
+                    <option value="good-bad-ideas">Good-Bad-Ideas</option>
+                    <option value="kalm">Keep-Add-Less-More</option>
+                    <option value="start-stop-continue">Start-Stop-Continue</option>
+                    <option value="psy-safety">Psychological Safety</option>
+                    <option value="wlai">Went Well-Learned-Accelerators-Impediments</option>
                     <option value="clarity">Clarity</option>
                     <option value="energy">Energy</option>
-                    <option value="psy-safety">Psychological Safety</option>
                     <option value="wlb">Work-life Balance</option>
                     <option value="team-confidence">Team Confidence</option>
-                    <option value="team-efficiency">Team Efficiency</option>
                   </select>
                 </div>
                 <List

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -441,7 +441,7 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
                     <option value="daki">Drop-Add-Keep-Improve</option>
                     <option value="kalm">Keep-Add-Less-More</option>
                     <option value="wlai">Went Well-Learned-Accelerators-Impediments</option>
-                    <option value="team-confidence">Team Confidence</option>
+                    <option value="1to1">1-to-1</option>
                     <option value="clarity">Clarity</option>
                     <option value="energy">Energy</option>
                     <option value="psy-safety">Psychological Safety</option>

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -85,7 +85,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
 
     setSelectAllChecked(allVisibleIdsAreInFilteredOptions);
   };
-/*
+
   const orderedPermissionOptions = (options: FeedbackBoardPermissionOption[]): FeedbackBoardPermissionOption[] => {
     const orderedPermissionOptions = options
       .map(o => {
@@ -93,36 +93,26 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
         return o;
       })
       .sort((a, b) => {
+
+        // Step 1: Ensure the board owner appears first
+        const isAOwner = a.id === props.board?.createdBy?.id;
+        const isBOwner = b.id === props.board?.createdBy?.id;
+        if (isAOwner && !isBOwner) return -1;
+        if (!isAOwner && isBOwner) return 1;
+
+        // Step 2: Sort by hasPermission (true before false)
         if (a.hasPermission !== b.hasPermission) {
           return b.hasPermission ? 1 : -1;
         }
 
-        return a.name.localeCompare(b.name);
-      });
-
-    return orderedPermissionOptions;
-  }
-*/
-  const orderedPermissionOptions = (options: FeedbackBoardPermissionOption[]): FeedbackBoardPermissionOption[] => {
-    const orderedPermissionOptions = options
-      .map(o => {
-        o.hasPermission = teamPermissions.includes(o.id) || memberPermissions.includes(o.id);
-        return o;
-      })
-      .sort((a, b) => {
-        // Step 1: Sort by hasPermission (true before false)
-        if (a.hasPermission !== b.hasPermission) {
-          return b.hasPermission ? 1 : -1;
-        }
-
-        // Step 2: Sort by type (team before member)
+        // Step 3: Sort by type (team before member)
         if (a.type === 'team' && b.type === 'member') {
           return -1;
         } else if (a.type === 'member' && b.type === 'team') {
           return 1;
         }
 
-        // Step 3: Sort alphabetically by name
+        // Step 4: Sort alphabetically by name
         return a.name.localeCompare(b.name);
       });
 

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -124,7 +124,9 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
         }
 
         // Step 3: Sort by hasPermission, with true before false
-        return b.hasPermission - a.hasPermission; // b.hasPermission - a.hasPermission sorts true (1) before false (0)
+        const aPermissionValue = a.hasPermission ? 1 : 0;
+        const bPermissionValue = b.hasPermission ? 1 : 0;
+        return bPermissionValue - aPermissionValue; // Explicitly convert booleans to numbers
       });
 
     return orderedPermissionOptions;

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -110,23 +110,20 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
         return o;
       })
       .sort((a, b) => {
-        // Step 1: Sort alphabetically by name
-        const nameComparison = a.name.localeCompare(b.name);
-        if (nameComparison !== 0) {
-          return nameComparison;
+        // Step 1: Sort by hasPermission (true before false)
+        if (a.hasPermission !== b.hasPermission) {
+          return b.hasPermission ? -1 : 1;
         }
 
-        // Step 2: Sort by type, with teams before members
+        // Step 2: Sort by type (team before member)
         if (a.type === 'team' && b.type === 'member') {
           return -1;
         } else if (a.type === 'member' && b.type === 'team') {
           return 1;
         }
 
-        // Step 3: Sort by hasPermission, with true before false
-        const aPermissionValue = a.hasPermission ? 1 : 0;
-        const bPermissionValue = b.hasPermission ? 1 : 0;
-        return bPermissionValue - aPermissionValue; // Explicitly convert booleans to numbers
+        // Step 3: Sort alphabetically by name
+        return a.name.localeCompare(b.name);
       });
 
     return orderedPermissionOptions;

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -112,7 +112,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
       .sort((a, b) => {
         // Step 1: Sort by hasPermission (true before false)
         if (a.hasPermission !== b.hasPermission) {
-          return b.hasPermission ? -1 : 1;
+          return b.hasPermission ? 1 : -1;
         }
 
         // Step 2: Sort by type (team before member)

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -85,7 +85,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
 
     setSelectAllChecked(allVisibleIdsAreInFilteredOptions);
   };
-
+/*
   const orderedPermissionOptions = (options: FeedbackBoardPermissionOption[]): FeedbackBoardPermissionOption[] => {
     const orderedPermissionOptions = options
       .map(o => {
@@ -102,6 +102,33 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
 
     return orderedPermissionOptions;
   }
+*/
+  const orderedPermissionOptions = (options: FeedbackBoardPermissionOption[]): FeedbackBoardPermissionOption[] => {
+    const orderedPermissionOptions = options
+      .map(o => {
+        o.hasPermission = teamPermissions.includes(o.id) || memberPermissions.includes(o.id);
+        return o;
+      })
+      .sort((a, b) => {
+        // Step 1: Sort alphabetically by name
+        const nameComparison = a.name.localeCompare(b.name);
+        if (nameComparison !== 0) {
+          return nameComparison;
+        }
+
+        // Step 2: Sort by type, with teams before members
+        if (a.type === 'team' && b.type === 'member') {
+          return -1;
+        } else if (a.type === 'member' && b.type === 'team') {
+          return 1;
+        }
+
+        // Step 3: Sort by hasPermission, with true before false
+        return b.hasPermission - a.hasPermission; // b.hasPermission - a.hasPermission sorts true (1) before false (0)
+      });
+
+    return orderedPermissionOptions;
+  };
 
   const emitChangeEvent = () => {
     props.onPermissionChanged({

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -93,25 +93,21 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
         return o;
       })
       .sort((a, b) => {
-
         // Step 1: Ensure the board owner appears first
         const isAOwner = a.id === props.board?.createdBy?.id;
         const isBOwner = b.id === props.board?.createdBy?.id;
         if (isAOwner && !isBOwner) return -1;
         if (!isAOwner && isBOwner) return 1;
-
         // Step 2: Sort by hasPermission (true before false)
         if (a.hasPermission !== b.hasPermission) {
           return b.hasPermission ? 1 : -1;
         }
-
         // Step 3: Sort by type (team before member)
         if (a.type === 'team' && b.type === 'member') {
           return -1;
         } else if (a.type === 'member' && b.type === 'team') {
           return 1;
         }
-
         // Step 4: Sort alphabetically by name
         return a.name.localeCompare(b.name);
       });

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -135,7 +135,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
   const PublicWarningBanner = () => {
     if(teamPermissions.length === 0 && memberPermissions.length === 0) {
       return <div className="board-metadata-form-section-information">
-        <i className="fas fa-exclamation-circle" aria-label="Board is visible to every member in the organization"></i>&nbsp;This board is visible to every member in the organization.
+        <i className="fas fa-exclamation-circle" aria-label="Board is visible to every member in the project"></i>&nbsp;This board is visible to every member in the project.
       </div>
     }
 


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #983 

## Description

Starts over with clean fix for blank and duplicate permissions.  Blank permissions was introduced when removed All Teams.  Some code was being used to find all the teams the user was a member of.  That code was restored.  Duplicates occurred when the user was a member of more than one team.  The code added all the members for each team, regardless if they were duplicates.  The code now removes the duplicates.

Also changes the sort order to:
1) Owner 
2) Teams with permission sorted alphabetically
3) Users with permission sorted alphabetically
4) Teams without permission sorted alphabetically
5) Users without permission sorted alphabetically

Known bug: When creating a new board, the permission will show the owner for the current board, not the board creator, until saved, then will show the board creator as owner.

## Bug or Feature?

- [x] Bug fix
- [x] New feature
