### PR TITLE
Updating NPM Clean Cmd to Build Correctly on Windows

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -53,6 +53,7 @@
         "compression-webpack-plugin": "11.1.0",
         "crypto-browserify": "3.12.1",
         "css-loader": "7.1.2",
+        "del-cli": "^6.0.0",
         "enzyme": "3.11.0",
         "eslint": "9.22.0",
         "eslint-plugin-react": "7.37.4",
@@ -5786,6 +5787,58 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/del": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-8.0.0.tgz",
+      "integrity": "sha512-R6ep6JJ+eOBZsBr9esiNN1gxFbZE4Q2cULkUSFumGYecAiS6qodDvcPx/sFuWHMNul7DWmrtoEOpYSm7o6tbSA==",
+      "dev": true,
+      "dependencies": {
+        "globby": "^14.0.2",
+        "is-glob": "^4.0.3",
+        "is-path-cwd": "^3.0.0",
+        "is-path-inside": "^4.0.0",
+        "p-map": "^7.0.2",
+        "slash": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del-cli/-/del-cli-6.0.0.tgz",
+      "integrity": "sha512-9nitGV2W6KLFyya4qYt4+9AKQFL+c0Ehj5K7V7IwlxTc6RMCfQUGY9E9pLG6e8TQjtwXpuiWIGGZb3mfVxyZkw==",
+      "dev": true,
+      "dependencies": {
+        "del": "^8.0.0",
+        "meow": "^13.2.0"
+      },
+      "bin": {
+        "del": "cli.js",
+        "del-cli": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -8622,6 +8675,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-path-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
+      "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
@@ -11120,6 +11197,18 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -4,7 +4,7 @@
   "description": "Azure DevOps Retrospective Extension",
   "main": "index.tsx",
   "scripts": {
-    "clean": "npx rimraf ./dist ./coverage ./reports ./node_modules/applicationinsights-js/dist/*.map",
+    "clean": "npx rimraf ./dist ./coverage ./reports && npx del-cli ./node_modules/applicationinsights-js/dist/*.map",
     "compile": "npx tailwindcss -i ./css/index.css -o ./css/bundle.css --minify",
     "build:p": "npm run clean && npm run compile && npx webpack --mode=production",
     "lint": "npx eslint **/*.ts*",
@@ -70,6 +70,7 @@
     "compression-webpack-plugin": "11.1.0",
     "crypto-browserify": "3.12.1",
     "css-loader": "7.1.2",
+    "del-cli": "^6.0.0",
     "enzyme": "3.11.0",
     "eslint": "9.22.0",
     "eslint-plugin-react": "7.37.4",


### PR DESCRIPTION
# Pull Request

Updating `npm run clean` command to run correctly on Windows and overall build of the frontend extension

## Description

Updating `npm run clean` command to run correctly on Windows and overall build of the frontend extension:

`"clean": "npx rimraf ./dist ./coverage ./reports && npx del-cli ./node_modules/applicationinsights-js/dist/*.map",`

Follow dev dependency has been added:
`npm install del-cli --save-dev`

## Bug or Feature?

- [x] Bug fix
- [ ] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md)
document.
- [x] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly. N/A
- [ ] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`,
    to be included with the next release. N/A
  - [ ] I have included a link to this PR in that blurb.
- [ ] I have added tests to cover my changes. N/A
- [x] All new and existing tests passed. Yes, extension built successfully

## Accessibility
N/A all
- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

<!-- Do you have any screenshots or logs that would show off your fix? -->
