### PR TITLE
Add delete after archive from history tab

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -382,7 +382,7 @@ VS Code extension
 The Retrospectives extension uses the
 [Azure SignalR service](https://azure.microsoft.com/en-us/services/signalr-service/)
 to add real time support. The backend codebase can be found
-[here](https://github.com/microsoft/vsts-extension-retrospectives/tree/main/RetrospectiveExtension.Backend).
+[Retrospectives Extension Backend Repository](https://github.com/microsoft/vsts-extension-retrospectives/tree/main/RetrospectiveExtension.Backend).
 
 To enable real time updates from your test extension you will need to deploy
 the backend to Azure specifying your publisher ID and the unique key of your

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -31,7 +31,8 @@ import {
 export interface IBoardSummaryTableProps {
   teamId: string;
   supportedWorkItemTypes: WorkItemType[];
-  onArchiveToggle: () => void; // Notify the parent about archive toggles
+  onArchiveToggle: () => void;
+  showDeleteBoardConfirmationDialog: (boardId: string) => void; // ✅ Add delete function
 }
 
 export interface IBoardSummaryTableState {
@@ -279,14 +280,17 @@ function getTable(
           <i className="fas fa-trash-alt" style={{ color: 'white' }} title="Delete board"></i>
         </div>
       ),
-        cell: (cellContext) => (
-      <div
-        className="centered-cell trash-icon"
-        title="Delete board"
-        onClick={(event) => event.stopPropagation()} // Prevent row expansion on any click
-      >
-        {cellContext.row.original.isArchived && <i className="fas fa-trash-alt"></i>}
-      </div>
+      cell: ({ row }) => (
+        <div
+          className="centered-cell trash-icon"
+          title="Delete board"
+          onClick={(event) => {
+            event.stopPropagation(); // Prevent row expansion
+            props.showDeleteBoardConfirmationDialog(row.original.id); // ✅ Call delete function
+          }}
+        >
+          {row.original.isArchived && <i className="fas fa-trash-alt"></i>}
+        </div>
       ),
       size: 45,
       enableSorting: false,

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -327,7 +327,7 @@ function getTable(
           }}>
           <DialogContent>
             <p>
-              The retrospective board "{selectedBoard.boardName}" with {selectedBoard.feedbackItemsCount} feedback items will be deleted.
+              The retrospective board &quot;{selectedBoard.boardName}&quot; with {selectedBoard.feedbackItemsCount} feedback items will be deleted.
             </p>
             <p style={{ fontStyle: "italic" }}>
               This action is permanent and cannot be undone.

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -195,7 +195,7 @@ function getTable(
   const columnHelper = createColumnHelper<IBoardSummaryTableItem>();
   const defaultFooter = (info: HeaderContext<IBoardSummaryTableItem, unknown>) => info.column.id;
   // DPH
-  const setRefreshKey = useState(0);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const columns = [
     columnHelper.accessor('id', {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -7,7 +7,7 @@ import { workItemService } from '../dal/azureDevOpsWorkItemService';
 import BoardSummary from './boardSummary';
 import { withAITracking } from '@microsoft/applicationinsights-react-js';
 import { appInsights, reactPlugin, TelemetryEvents } from '../utilities/telemetryClient';
-import { DefaultButton, Dialog, DialogFooter, PrimaryButton, Spinner, SpinnerSize } from 'office-ui-fabric-react';
+import { DefaultButton, Dialog, DialogFooter, DialogType, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import { flexRender, useReactTable } from '@tanstack/react-table';
 
 import {
@@ -294,7 +294,7 @@ function getTable(
     const selectedBoard = cellContext.row.original;
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-    const dialogMessage = `The retrospective board "${selectedBoard.boardName}" with ${selectedBoard.feedbackItemsCount} feedback items will be deleted. This action is permanent and cannot be undone.`;
+    const dialogMessage = `The retrospective board "${selectedBoard.boardName}" with ${selectedBoard.feedbackItemsCount} feedback items will be deleted.\n\nThis action is permanent and cannot be undone.`;
 
     const handleTrashClick = (event: React.MouseEvent) => {
       event.stopPropagation(); // Prevent row expansion on click
@@ -318,10 +318,15 @@ function getTable(
               hidden={!isDeleteDialogOpen}
               onDismiss={handleCancelDelete}
               dialogContentProps={{
-                title: 'Confirm Deletion',
+                type: DialogType.close,
+                title: 'Delete Retrospective',
                 subText: dialogMessage,
               }}
-            >
+              modalProps={{
+                isBlocking: true,
+                containerClassName: 'retrospectives-delete-board-confirmation-dialog',
+                className: 'retrospectives-dialog-modal',
+              }}>
               <DialogFooter>
                 <DefaultButton onClick={handleCancelDelete} text="Cancel" />
               </DialogFooter>

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -290,55 +290,48 @@ function getTable(
           <i className="fas fa-trash-alt" style={{ color: 'white' }} title="Delete board"></i>
         </div>
       ),
-      cell: (cellContext) => (
-        <>
-          <div
-            className="centered-cell trash-icon"
-            title="Delete board"
-            onClick={handleTrashClick}
-          >
-            {cellContext.row.original.isArchived && <i className="fas fa-trash-alt"></i>}
-          </div>
+  cell: (cellContext) => {
+    const selectedBoard = cellContext.row.original;
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-          {/* Dialog component */}
-          <Dialog
-            hidden={!isDeleteDialogOpen}
-            onDismiss={handleCancelDelete}
-            dialogContentProps={{
-              title: 'Confirm Deletion',
-              subText: 'The retrospective board and all its feedback will be deleted. This action is permanent and cannot be undone.',
-            }}
-          >
-            <DialogFooter>
-              <DefaultButton onClick={handleCancelDelete} text="Cancel" />
-            </DialogFooter>
-          </Dialog>
-        </>
-      ),
-      size: 45,
-      enableSorting: false,
-    })
-/*
-    columnHelper.display({
-      id: 'trash',
-      header: () => (
-        <div className="centered-cell">
-          <i className="fas fa-trash-alt" style={{ color: 'white' }} title="Delete board"></i>
+    const dialogMessage = `The retrospective board "${selectedBoard.boardName}" with ${selectedBoard.feedbackItemsCount} feedback items will be deleted. This action is permanent and cannot be undone.`;
+
+    const handleTrashClick = (event: React.MouseEvent) => {
+      event.stopPropagation(); // Prevent row expansion on click
+      setIsDeleteDialogOpen(true);
+    };
+
+    const handleCancelDelete = () => {
+      setIsDeleteDialogOpen(false);
+    };
+
+    return (
+      <>
+        <div
+          className="centered-cell trash-icon"
+          title="Delete board"
+          onClick={handleTrashClick}
+        >
+          {selectedBoard.isArchived && <i className="fas fa-trash-alt"></i>}
         </div>
-      ),
-        cell: (cellContext) => (
-      <div
-        className="centered-cell trash-icon"
-        title="Delete board"
-        onClick={(event) => event.stopPropagation()} // Prevent row expansion on any click
-      >
-        {cellContext.row.original.isArchived && <i className="fas fa-trash-alt"></i>}
-      </div>
-      ),
+            <Dialog
+              hidden={!isDeleteDialogOpen}
+              onDismiss={handleCancelDelete}
+              dialogContentProps={{
+                title: 'Confirm Deletion',
+                subText: dialogMessage,
+              }}
+            >
+              <DialogFooter>
+                <DefaultButton onClick={handleCancelDelete} text="Cancel" />
+              </DialogFooter>
+            </Dialog>
+          </>
+        );
+      },
       size: 45,
       enableSorting: false,
     })
-*/
   ]
 
   const tableOptions: TableOptions<IBoardSummaryTableItem> = {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -296,38 +296,7 @@ function getTable(
         setIsDeleteDialogOpen(false);
       };
 
-const handleConfirmDelete = async (selectedBoard: IBoardSummaryTableItem) => {
-  try {
-    await BoardDataService.deleteFeedbackBoard(selectedBoard.teamId, selectedBoard.id);
-    reflectBackendService.broadcastDeletedBoard(selectedBoard.teamId, selectedBoard.id);
-
-    // Update local state to remove the deleted board from the table
-    setTableData((prevData) => prevData.filter(board => board.id !== selectedBoard.id));
-
-    // Track the event
-    appInsights.trackEvent({
-      name: TelemetryEvents.FeedbackBoardDeleted,
-      properties: {
-        boardId: selectedBoard.id,
-        boardName: selectedBoard.boardName,
-        deletedByUserId: encrypt(getUserIdentity().id),
-      }
-    });
-
-    setIsDeleteDialogOpen(false);
-
-  } catch (error: unknown) {
-  if (error instanceof Error && 'response' in error && (error.response as { status?: number }).status === 404) {
-      // Board already deleted, just update the table and close the dialog
-      setTableData((prevData) => prevData.filter(board => board.id !== selectedBoard.id));
-      setIsDeleteDialogOpen(false);
-    } else {
-      console.error("Error deleting board:", error);
-    }
-  }
-};
-
-      const DPH_handleConfirmDelete = async (selectedBoard: IBoardSummaryTableItem) => {
+      const handleConfirmDelete = async (selectedBoard: IBoardSummaryTableItem) => {
         try {
           await BoardDataService.deleteFeedbackBoard(selectedBoard.teamId, selectedBoard.id);
           reflectBackendService.broadcastDeletedBoard(selectedBoard.teamId, selectedBoard.id);
@@ -344,10 +313,22 @@ const handleConfirmDelete = async (selectedBoard: IBoardSummaryTableItem) => {
               deletedByUserId: encrypt(getUserIdentity().id),
             }
           });
-
-        } catch (error) {
-          console.error("Error deleting board:", error);
         }
+        catch (error: unknown) {
+  if (error instanceof Error && 'response' in error && (error.response as { status?: number }).status === 404) {
+    // Board already deleted, just update the table and close the dialog
+    setIsDeleteDialogOpen(false);
+    console.log("Caught the 404.");
+    setTableData(prevData => prevData.filter(board => board.id !== selectedBoard.id));
+  } else {
+    console.error("Error deleting board:", error);
+  }
+}
+/* catch (error) {
+          console.error("Error deleting board:", error);
+          BoardDataService.getBoardsForTeam(props.teamId).then(handleBoardsDocuments);
+        }
+*/
       };
 
 // DPH

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -55,7 +55,7 @@ export interface IBoardSummaryTableItem {
   feedbackItemsCount: number;
   id: string; // Board ID
   teamId: string;
-  ownerId: string; // DPH
+  ownerId: string;
 }
 
 export interface IBoardActionItemsData {
@@ -189,7 +189,6 @@ function getTable(
   sortingState: SortingState,
   onSortingChange: OnChangeFn<SortingState>,
   onArchiveToggle: () => void,
-  // isDataLoaded: boolean, // DPH if remove then expect only 5 arguments
   setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>,
   setRefreshKey: React.Dispatch<React.SetStateAction<boolean>>
 ): Table<IBoardSummaryTableItem> {
@@ -276,7 +275,6 @@ function getTable(
       footer: defaultFooter,
       size: 80,
     }),
-    // DPH delete
     columnHelper.display({
       id: 'trash',
       header: () => (
@@ -317,14 +315,11 @@ function getTable(
 
         } catch (error) {
           console.error("Error deleting board:", error);
-          // DPH
-          // trigger refresh to resolve issue
           setRefreshKey(true);
           setIsDeleteDialogOpen(false);
         }
       };
 
-// DPH
       return (
         <>
           <div
@@ -405,11 +400,10 @@ function BoardSummaryTable(props: Readonly<IBoardSummaryTableProps>): JSX.Elemen
     setTableData(boardSummaryState.boardsTableItems);
   }, [boardSummaryState.boardsTableItems]);
 
-  // DPH
   const [refreshKey, setRefreshKey] = useState(false);
 
   const table: Table<IBoardSummaryTableItem> =
-    getTable(tableData, sorting, setSorting, props.onArchiveToggle, setTableData, setRefreshKey); // DPH boardSummaryState.isDataLoaded,
+    getTable(tableData, sorting, setSorting, props.onArchiveToggle, setTableData, setRefreshKey);
 
   const updatedState: IBoardSummaryTableState = { ...boardSummaryState };
 
@@ -432,7 +426,7 @@ function BoardSummaryTable(props: Readonly<IBoardSummaryTableProps>): JSX.Elemen
           feedbackItemsCount: 0,
           id: board.id,
           teamId: board.teamId,
-          ownerId: board.createdBy.id, // DPH
+          ownerId: board.createdBy.id,
         };
 
         boardsTableItems.push(boardSummaryItem);
@@ -602,7 +596,7 @@ function BoardSummaryTable(props: Readonly<IBoardSummaryTableProps>): JSX.Elemen
       'aria-readonly': true
     };
   }
-// DPH
+
   useEffect(() => {
   if (teamId !== props.teamId || refreshKey) { // Triggers when teamId changes OR refreshKey is true
     BoardDataService.getBoardsForTeam(props.teamId).then((boardDocuments: IFeedbackBoardDocument[]) => {
@@ -615,18 +609,7 @@ function BoardSummaryTable(props: Readonly<IBoardSummaryTableProps>): JSX.Elemen
     });
   }
 }, [props.teamId, refreshKey]); // Runs when teamId or refreshKey updates
-/*
-  useEffect(() => {
-    if(teamId !== props.teamId || refreshKey > 0) {
-      BoardDataService.getBoardsForTeam(props.teamId).then((boardDocuments: IFeedbackBoardDocument[]) => {
-        setTeamId(props.teamId);
-        handleBoardsDocuments(boardDocuments);
-      }).catch(e => {
-        appInsights.trackException(e);
-      })
-    }
-  }, [props.teamId, refreshKey])
-*/
+
   if(boardSummaryState.allDataLoaded !== true) {
     return <Spinner className="board-summary-initialization-spinner"
       size={SpinnerSize.large}

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -155,8 +155,8 @@ const reloadBoardHistory = async (
 const formattedData: IBoardSummaryTableItem[] = updatedBoardData.map(board => ({
   id: board.id,
   teamId: board.teamId,
-  boardName: (board as any).boardName || "Untitled Board", 
-  createdDate: board.createdDate ? new Date(board.createdDate) : new Date(), 
+  boardName: (board as any).boardName || "Untitled Board",
+  createdDate: board.createdDate ? new Date(board.createdDate) : new Date(),
 pendingWorkItemsCount: (board as any).pendingWorkItemsCount ?? 0,
 totalWorkItemsCount: (board as any).totalWorkItemsCount ?? 0,
 feedbackItemsCount: (board as any).feedbackItemsCount ?? 0,

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -222,7 +222,7 @@ function getTable(
       cell: (cellContext: CellContext<IBoardSummaryTableItem, Date>) => {
         return dateFormatter.format(cellContext.row.original.createdDate);
       },
-      size: 120,
+      size: 110,
       sortDescFirst: true
     }),
     columnHelper.accessor('isArchived', {
@@ -259,18 +259,18 @@ function getTable(
         const archivedDate = cellContext.row.original.archivedDate;
         return archivedDate ? dateFormatter.format(archivedDate) : '';
       },
-      size: 120,
+      size: 110,
       sortDescFirst: true
     }),
     columnHelper.accessor('feedbackItemsCount', {
       header: 'Feedback Items',
       footer: defaultFooter,
-      size: 110,
+      size: 100,
     }),
     columnHelper.accessor('totalWorkItemsCount', {
       header: 'Total Work Items',
       footer: defaultFooter,
-      size: 110,
+      size: 100,
     }),
     // DPH delete
     // NEW COLUMN: Trash Can

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -7,7 +7,7 @@ import { workItemService } from '../dal/azureDevOpsWorkItemService';
 import BoardSummary from './boardSummary';
 import { withAITracking } from '@microsoft/applicationinsights-react-js';
 import { appInsights, reactPlugin, TelemetryEvents } from '../utilities/telemetryClient';
-import { DefaultButton, Spinner, SpinnerSize } from 'office-ui-fabric-react';
+import { DefaultButton, Dialog, DialogFooter, PrimaryButton, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import { flexRender, useReactTable } from '@tanstack/react-table';
 
 import {
@@ -139,6 +139,17 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
 });
+
+const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+const handleTrashClick = (event: React.MouseEvent) => {
+  event.stopPropagation(); // Prevent row expansion on click
+  setIsDeleteDialogOpen(true);
+};
+
+const handleCancelDelete = () => {
+  setIsDeleteDialogOpen(false);
+};
 
 async function handleArchiveToggle(
   teamId: string,
@@ -279,6 +290,42 @@ function getTable(
           <i className="fas fa-trash-alt" style={{ color: 'white' }} title="Delete board"></i>
         </div>
       ),
+      cell: (cellContext) => (
+        <>
+          <div
+            className="centered-cell trash-icon"
+            title="Delete board"
+            onClick={handleTrashClick}
+          >
+            {cellContext.row.original.isArchived && <i className="fas fa-trash-alt"></i>}
+          </div>
+
+          {/* Dialog component */}
+          <Dialog
+            hidden={!isDeleteDialogOpen}
+            onDismiss={handleCancelDelete}
+            dialogContentProps={{
+              title: 'Confirm Deletion',
+              subText: 'The retrospective board and all its feedback will be deleted. This action is permanent and cannot be undone.',
+            }}
+          >
+            <DialogFooter>
+              <DefaultButton onClick={handleCancelDelete} text="Cancel" />
+            </DialogFooter>
+          </Dialog>
+        </>
+      ),
+      size: 45,
+      enableSorting: false,
+    })
+/*
+    columnHelper.display({
+      id: 'trash',
+      header: () => (
+        <div className="centered-cell">
+          <i className="fas fa-trash-alt" style={{ color: 'white' }} title="Delete board"></i>
+        </div>
+      ),
         cell: (cellContext) => (
       <div
         className="centered-cell trash-icon"
@@ -291,6 +338,7 @@ function getTable(
       size: 45,
       enableSorting: false,
     })
+*/
   ]
 
   const tableOptions: TableOptions<IBoardSummaryTableItem> = {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -144,6 +144,33 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+// DPH
+const reloadBoardHistory = async (
+  teamId: string,
+  setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>
+) => {
+  try {
+    const updatedBoardData: IFeedbackBoardDocument[] = await BoardDataService.getBoardsForTeam(teamId);
+
+    // Convert `IFeedbackBoardDocument` to `IBoardSummaryTableItem`
+    const formattedData: IBoardSummaryTableItem[] = updatedBoardData.map(board => ({
+      id: board.id,
+      teamId: board.teamId,
+      boardName: board.boardName || "Untitled Board", 
+      pendingWorkItemsCount: board.pendingWorkItemsCount ?? 0,
+      totalWorkItemsCount: board.totalWorkItemsCount ?? 0,
+      feedbackItemsCount: board.feedbackItemsCount ?? 0,
+      ownerId: board.ownerId || "Unknown Owner",
+      isArchived: board.isArchived ?? false,
+      createdDate: board.createdDate ?? new Date(), // ✅ Add `createdDate`
+    }));
+
+    setTableData(formattedData); // Now passing correctly formatted data
+  } catch (error) {
+    console.error("Error reloading board history:", error);
+  }
+};
+
 async function handleArchiveToggle(
   teamId: string,
   boardId: string,
@@ -317,6 +344,8 @@ function getTable(
         } catch (error) {
           console.error("Error deleting board:", error);
           setIsDeleteDialogOpen(false);
+          // Trigger board history reload since board may have been delete
+          reloadBoardHistory(selectedBoard.teamId, setTableData);
         }
       };
 

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -31,8 +31,7 @@ import {
 export interface IBoardSummaryTableProps {
   teamId: string;
   supportedWorkItemTypes: WorkItemType[];
-  onArchiveToggle: () => void;
-  showDeleteBoardConfirmationDialog: (boardId: string) => void; // ✅ Add delete function
+  onArchiveToggle: () => void; // Notify the parent about archive toggles
 }
 
 export interface IBoardSummaryTableState {
@@ -280,17 +279,14 @@ function getTable(
           <i className="fas fa-trash-alt" style={{ color: 'white' }} title="Delete board"></i>
         </div>
       ),
-      cell: ({ row }) => (
-        <div
-          className="centered-cell trash-icon"
-          title="Delete board"
-          onClick={(event) => {
-            event.stopPropagation(); // Prevent row expansion
-            props.showDeleteBoardConfirmationDialog(row.original.id); // ✅ Call delete function
-          }}
-        >
-          {row.original.isArchived && <i className="fas fa-trash-alt"></i>}
-        </div>
+        cell: (cellContext) => (
+      <div
+        className="centered-cell trash-icon"
+        title="Delete board"
+        onClick={(event) => event.stopPropagation()} // Prevent row expansion on any click
+      >
+        {cellContext.row.original.isArchived && <i className="fas fa-trash-alt"></i>}
+      </div>
       ),
       size: 45,
       enableSorting: false,

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -192,7 +192,7 @@ function getTable(
   sortingState: SortingState,
   onSortingChange: OnChangeFn<SortingState>,
   onArchiveToggle: () => void,
-  isDataLoaded: boolean, // DPH if remove need to make other changes to expect only 5 arguments
+  // isDataLoaded: boolean, // DPH if remove then expect only 5 arguments
   setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>
 ): Table<IBoardSummaryTableItem> {
   const columnHelper = createColumnHelper<IBoardSummaryTableItem>();
@@ -404,7 +404,7 @@ function BoardSummaryTable(props: Readonly<IBoardSummaryTableProps>): JSX.Elemen
   }, [boardSummaryState.boardsTableItems]);
 
   const table: Table<IBoardSummaryTableItem> =
-    getTable(tableData, sorting, setSorting, props.onArchiveToggle, boardSummaryState.isDataLoaded, setTableData);
+    getTable(tableData, sorting, setSorting, props.onArchiveToggle, setTableData); // DPH boardSummaryState.isDataLoaded,
 
   const updatedState: IBoardSummaryTableState = { ...boardSummaryState };
 

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -222,7 +222,7 @@ function getTable(
       cell: (cellContext: CellContext<IBoardSummaryTableItem, Date>) => {
         return dateFormatter.format(cellContext.row.original.createdDate);
       },
-      size: 110,
+      size: 120,
       sortDescFirst: true
     }),
     columnHelper.accessor('isArchived', {
@@ -259,13 +259,13 @@ function getTable(
         const archivedDate = cellContext.row.original.archivedDate;
         return archivedDate ? dateFormatter.format(archivedDate) : '';
       },
-      size: 110,
+      size: 120,
       sortDescFirst: true
     }),
     columnHelper.accessor('feedbackItemsCount', {
       header: 'Feedback Items',
       footer: defaultFooter,
-      size: 100,
+      size: 90,
     }),
     columnHelper.accessor('totalWorkItemsCount', {
       header: 'Total Work Items',
@@ -289,7 +289,7 @@ function getTable(
           </div>
         ) : null;
       },
-      size: 90,
+      size: 30,
       enableSorting: false,
       //enableResizing: false
     }),

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -78,9 +78,6 @@ interface BoardSummaryTableBodyProps {
   boardRowSummary: (row: Row<IBoardSummaryTableItem>) => JSX.Element;
 }
 
-//DPH
-const currentUserId = encrypt(getUserIdentity().id);
-
 const BoardSummaryTableHeader: React.FC<BoardSummaryTableHeaderProps> = ({ headerGroups, getThProps }) => (
   <thead role="rowgroup">
     {headerGroups.map((headerGroup) => (
@@ -312,8 +309,8 @@ function getTable(
             name: TelemetryEvents.FeedbackBoardDeleted,
             properties: {
               boardId: selectedBoard.id,
-              boardName: selectedBoard.boardName, // Assuming the board object has a 'name' property
-              deletedByUserId: currentUserId, // Ensure you have access to the current user
+              boardName: selectedBoard.boardName,
+              deletedByUserId: encrypt(getUserIdentity().id),
             }
           });
 

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -222,7 +222,7 @@ function getTable(
       cell: (cellContext: CellContext<IBoardSummaryTableItem, Date>) => {
         return dateFormatter.format(cellContext.row.original.createdDate);
       },
-      size: 120,
+      size: 100,
       sortDescFirst: true
     }),
     columnHelper.accessor('isArchived', {
@@ -259,18 +259,18 @@ function getTable(
         const archivedDate = cellContext.row.original.archivedDate;
         return archivedDate ? dateFormatter.format(archivedDate) : '';
       },
-      size: 120,
+      size: 100,
       sortDescFirst: true
     }),
     columnHelper.accessor('feedbackItemsCount', {
       header: 'Feedback Items',
       footer: defaultFooter,
-      size: 90,
+      size: 80,
     }),
     columnHelper.accessor('totalWorkItemsCount', {
       header: 'Total Work Items',
       footer: defaultFooter,
-      size: 90,
+      size: 80,
     }),
     // DPH delete
     // NEW COLUMN: Trash Can
@@ -289,7 +289,7 @@ function getTable(
           </div>
         ) : null;
       },
-      size: 30,
+      size: 40,
       enableSorting: false,
       //enableResizing: false
     }),

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -273,7 +273,6 @@ function getTable(
       size: 80,
     }),
     // DPH delete
-    // NEW COLUMN: Trash Can
     columnHelper.display({
       id: 'trash',
       header: () => (
@@ -295,7 +294,7 @@ function getTable(
       },
       size: 45,
       enableSorting: false,
-    });
+    })
   ]
 
   const tableOptions: TableOptions<IBoardSummaryTableItem> = {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -189,10 +189,10 @@ async function handleArchiveToggle(
 const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
 // DPH
-const handleTrashClick = async (  
-  event: React.MouseEvent, 
-  teamId: string, 
-  boardId: string, 
+const handleTrashClick = async (
+  event: React.MouseEvent,
+  teamId: string,
+  boardId: string,
   setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>
 ) => {
   event.stopPropagation(); // Prevent row expansion

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -156,7 +156,7 @@ const reloadBoardHistory = async (
     const formattedData: IBoardSummaryTableItem[] = updatedBoardData.map(board => ({
       id: board.id,
       teamId: board.teamId,
-      boardName: board.boardName || "Untitled Board", 
+      boardName: board.boardName || "Untitled Board",
       pendingWorkItemsCount: board.pendingWorkItemsCount ?? 0,
       totalWorkItemsCount: board.totalWorkItemsCount ?? 0,
       feedbackItemsCount: board.feedbackItemsCount ?? 0,

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -140,17 +140,6 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
-const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-
-const handleTrashClick = (event: React.MouseEvent) => {
-  event.stopPropagation(); // Prevent row expansion on click
-  setIsDeleteDialogOpen(true);
-};
-
-const handleCancelDelete = () => {
-  setIsDeleteDialogOpen(false);
-};
-
 async function handleArchiveToggle(
   teamId: string,
   boardId: string,
@@ -201,6 +190,17 @@ function getTable(
 ): Table<IBoardSummaryTableItem> {
   const columnHelper = createColumnHelper<IBoardSummaryTableItem>();
   const defaultFooter = (info: HeaderContext<IBoardSummaryTableItem, unknown>) => info.column.id;
+  // DPH 3
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  const handleTrashClick = (event: React.MouseEvent) => {
+    event.stopPropagation(); // Prevent row expansion on click
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleCancelDelete = () => {
+    setIsDeleteDialogOpen(false);
+  };
 
   const columns = [
     columnHelper.accessor('id', {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -320,6 +320,7 @@ function getTable(
 
       // DPH extend to project admin and org admin later
       const isAuthorized = selectedBoard.ownerId === currentUser.id;
+      // DPH reset to true after test and implement later
 
 // DPH
       return (

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -190,12 +190,11 @@ function getTable(
   onSortingChange: OnChangeFn<SortingState>,
   onArchiveToggle: () => void,
   // isDataLoaded: boolean, // DPH if remove then expect only 5 arguments
-  setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>
+  setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>,
+  setRefreshKey: React.Dispatch<React.SetStateAction<number>>
 ): Table<IBoardSummaryTableItem> {
   const columnHelper = createColumnHelper<IBoardSummaryTableItem>();
   const defaultFooter = (info: HeaderContext<IBoardSummaryTableItem, unknown>) => info.column.id;
-  // DPH
-  const [refreshKey, setRefreshKey] = useState(0);
 
   const columns = [
     columnHelper.accessor('id', {
@@ -406,8 +405,11 @@ function BoardSummaryTable(props: Readonly<IBoardSummaryTableProps>): JSX.Elemen
     setTableData(boardSummaryState.boardsTableItems);
   }, [boardSummaryState.boardsTableItems]);
 
+  // DPH
+  const [refreshKey, setRefreshKey] = useState(0);
+
   const table: Table<IBoardSummaryTableItem> =
-    getTable(tableData, sorting, setSorting, props.onArchiveToggle, setTableData); // DPH boardSummaryState.isDataLoaded,
+    getTable(tableData, sorting, setSorting, props.onArchiveToggle, setTableData, setRefreshKey); // DPH boardSummaryState.isDataLoaded,
 
   const updatedState: IBoardSummaryTableState = { ...boardSummaryState };
 

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -7,7 +7,7 @@ import { workItemService } from '../dal/azureDevOpsWorkItemService';
 import BoardSummary from './boardSummary';
 import { withAITracking } from '@microsoft/applicationinsights-react-js';
 import { appInsights, reactPlugin, TelemetryEvents } from '../utilities/telemetryClient';
-import { DefaultButton, Dialog, DialogFooter, DialogType, Spinner, SpinnerSize } from 'office-ui-fabric-react';
+import { DefaultButton, Dialog, DialogContent, DialogFooter, DialogType, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import { flexRender, useReactTable } from '@tanstack/react-table';
 
 import {
@@ -295,14 +295,6 @@ function getTable(
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
 //    const dialogMessage = `The retrospective board "${selectedBoard.boardName}" with ${selectedBoard.feedbackItemsCount} feedback item(s) will be deleted.\n\nThis action is permanent and cannot be undone.`;
-const dialogMessage = (
-  <>
-    <span>The retrospective board "{selectedBoard.boardName}" with {selectedBoard.feedbackItemsCount} feedback items will be deleted.</span>
-    <br />
-    <span style={{ fontStyle: 'italic' }}>This action is permanent and cannot be undone.</span>
-  </>
-);
-
     const handleTrashClick = (event: React.MouseEvent) => {
       event.stopPropagation(); // Prevent row expansion on click
       setIsDeleteDialogOpen(true);
@@ -321,26 +313,33 @@ const dialogMessage = (
         >
           {selectedBoard.isArchived && <i className="fas fa-trash-alt"></i>}
         </div>
-            <Dialog
-              hidden={!isDeleteDialogOpen}
-              onDismiss={handleCancelDelete}
-              dialogContentProps={{
-                type: DialogType.close,
-                title: 'Delete Retrospective',
-                subText: dialogMessage,
-              }}
-              modalProps={{
-                isBlocking: true,
-                containerClassName: 'retrospectives-delete-board-confirmation-dialog',
-                className: 'retrospectives-dialog-modal',
-              }}>
-              <DialogFooter>
-                <DefaultButton onClick={handleCancelDelete} text="Cancel" />
-              </DialogFooter>
-            </Dialog>
-          </>
-        );
-      },
+        <Dialog
+          hidden={!isDeleteDialogOpen}
+          onDismiss={handleCancelDelete}
+          dialogContentProps={{
+            type: DialogType.close,
+            title: 'Delete Retrospective',
+          }}
+          modalProps={{
+            isBlocking: true,
+            containerClassName: 'retrospectives-delete-board-confirmation-dialog',
+            className: 'retrospectives-dialog-modal',
+          }}>
+          <DialogContent>
+            <p>
+              The retrospective board "{selectedBoard.boardName}" with {selectedBoard.feedbackItemsCount} feedback items will be deleted.
+            </p>
+            <p style={{ fontStyle: "italic" }}>
+              This action is permanent and cannot be undone.
+            </p>
+          </DialogContent>
+          <DialogFooter>
+            <DefaultButton onClick={handleCancelDelete} text="Cancel" />
+          </DialogFooter>
+        </Dialog>
+      </>
+    );
+    },
       size: 45,
       enableSorting: false,
     })

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -184,67 +184,6 @@ async function handleArchiveToggle(
   }
 }
 
-// DPH
-// State for delete dialog
-const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-
-// DPH
-const handleTrashClick = async (
-  event: React.MouseEvent,
-  teamId: string,
-  boardId: string,
-  setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>
-) => {
-  event.stopPropagation(); // Prevent row expansion
-
-  try {
-    const boardExists = await BoardDataService.getBoardForTeamById(teamId, boardId);
-    if (!boardExists) {
-      alert("This board was already deleted by another user. Refreshing your view now.");
-      setTableData(prevData => prevData.filter(board => board.id !== boardId)); // Remove from UI
-      return;
-    }
-
-    setIsDeleteDialogOpen(true); // Open confirmation dialog
-  } catch (error) {
-    console.error("Error checking board existence:", error);
-  }
-};
-
-// DPH
-// Handles canceling the delete dialog
-const handleCancelDelete = () => {
-  setIsDeleteDialogOpen(false);
-};
-
-// DPH
-// Handles confirming the board deletion
-const handleConfirmDelete = async (
-  selectedBoard: IBoardSummaryTableItem,
-  setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>
-) => {
-  try {
-    await BoardDataService.deleteFeedbackBoard(selectedBoard.teamId, selectedBoard.id);
-    reflectBackendService.broadcastDeletedBoard(selectedBoard.teamId, selectedBoard.id);
-
-    // Update local state to remove the deleted board from the table
-    setTableData((prevData) => prevData.filter(board => board.id !== selectedBoard.id));
-
-    // Track the event
-    appInsights.trackEvent({
-      name: TelemetryEvents.FeedbackBoardDeleted,
-      properties: {
-        boardId: selectedBoard.id,
-        boardName: selectedBoard.boardName,
-        deletedByUserId: encrypt(getUserIdentity().id),
-      }
-    });
-
-  } catch (error) {
-    console.error("Error deleting board:", error);
-  }
-};
-
 function getTable(
   tableData: IBoardSummaryTableItem[],
   sortingState: SortingState,
@@ -337,7 +276,6 @@ function getTable(
       size: 80,
     }),
     // DPH delete
-
     columnHelper.display({
       id: 'trash',
       header: () => (
@@ -347,7 +285,6 @@ function getTable(
       ),
       cell: (cellContext) => {
         const selectedBoard = cellContext.row.original;
-        /*
         const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
         const handleTrashClick = (event: React.MouseEvent) => {
@@ -381,14 +318,14 @@ function getTable(
           console.error("Error deleting board:", error);
         }
       };
-*/
+
 // DPH
       return (
         <>
           <div
             className="centered-cell trash-icon"
             title="Delete board"
-            onClick={(event) => handleTrashClick(event, selectedBoard.teamId, selectedBoard.id, setTableData)}
+            onClick={handleTrashClick}
           >
             {selectedBoard.isArchived && <i className="fas fa-trash-alt"></i>}
           </div>
@@ -414,7 +351,7 @@ function getTable(
               </p>
             </DialogContent>
             <DialogFooter>
-              <PrimaryButton onClick={() => handleConfirmDelete(selectedBoard, setTableData)} text="Delete" />
+              <PrimaryButton onClick={() => handleConfirmDelete(selectedBoard)} text="Delete" />
               <DefaultButton autoFocus onClick={handleCancelDelete} text="Cancel" />
             </DialogFooter>
           </Dialog>

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -52,7 +52,6 @@ export interface IBoardSummaryTableItem {
   feedbackItemsCount: number;
   id: string; // Board ID
   teamId: string;
-//  trash?: boolean; // DPH delete
 }
 
 export interface IBoardActionItemsData {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -310,7 +310,7 @@ function getTable(
           // Track the event
           appInsights.trackEvent({
             name: TelemetryEvents.FeedbackBoardDeleted,
-            properties: { 
+            properties: {
               boardId: selectedBoard.id,
               boardName: selectedBoard.boardName, // Assuming the board object has a 'name' property
               deletedByUserId: currentUserId, // Ensure you have access to the current user

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -184,9 +184,6 @@ async function handleArchiveToggle(
   }
 }
 
-// DPH
-const [refreshKey, setRefreshKey] = useState(0);
-
 function getTable(
   tableData: IBoardSummaryTableItem[],
   sortingState: SortingState,
@@ -197,6 +194,8 @@ function getTable(
 ): Table<IBoardSummaryTableItem> {
   const columnHelper = createColumnHelper<IBoardSummaryTableItem>();
   const defaultFooter = (info: HeaderContext<IBoardSummaryTableItem, unknown>) => info.column.id;
+  // DPH
+  const setRefreshKey = useState(0);
 
   const columns = [
     columnHelper.accessor('id', {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -52,7 +52,7 @@ export interface IBoardSummaryTableItem {
   feedbackItemsCount: number;
   id: string; // Board ID
   teamId: string;
-  trash?: boolean; // DPH delete
+//  trash?: boolean; // DPH delete
 }
 
 export interface IBoardActionItemsData {
@@ -273,17 +273,20 @@ function getTable(
       size: 110,
     }),
     // DPH delete
-    columnHelper.accessor('trash', {
-      header: '',
-      footer: () => '',
+    // NEW COLUMN: Trash Can
+    columnHelper.display({
+      id: 'trash',
+      header: () => (
+        <div className="centered-cell">
+          <i className="fas fa-trash-alt" style={{ color: 'white' }} title="Delete board"></i>
+        </div>
+      ),
       cell: (cellContext: CellContext<IBoardSummaryTableItem, unknown>) => {
         const { isArchived } = cellContext.row.original;
-
-        // Show trash icon whenever isArchived is true (including after toggles)
         return isArchived ? (
-          <span className="trash-icon">
+          <div className="centered-cell trash-icon" title="Delete board">
             <i className="fas fa-trash-alt"></i>
-          </span>
+          </div>
         ) : null;
       },
       size: 35,

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -249,7 +249,7 @@ function getTable(
           </div>
         );
       },
-      size: 35,
+      size: 30,
       sortDescFirst: true,
     }),
     columnHelper.accessor('archivedDate', {
@@ -270,7 +270,7 @@ function getTable(
     columnHelper.accessor('totalWorkItemsCount', {
       header: 'Total Work Items',
       footer: defaultFooter,
-      size: 100,
+      size: 90,
     }),
     // DPH delete
     // NEW COLUMN: Trash Can
@@ -289,9 +289,9 @@ function getTable(
           </div>
         ) : null;
       },
-      size: 35,
+      size: 90,
       enableSorting: false,
-      enableResizing: false
+      //enableResizing: false
     }),
   ]
 

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -315,8 +315,9 @@ const handleConfirmDelete = async (selectedBoard: IBoardSummaryTableItem) => {
     });
 
     setIsDeleteDialogOpen(false);
-  } catch (error: any) {
-    if (error.response && error.response.status === 404) {
+
+  } catch (error: unknown) {
+  if (error instanceof Error && 'response' in error && (error.response as { status?: number }).status === 404) {
       // Board already deleted, just update the table and close the dialog
       setTableData((prevData) => prevData.filter(board => board.id !== selectedBoard.id));
       setIsDeleteDialogOpen(false);

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -316,6 +316,7 @@ function getTable(
 
         } catch (error) {
           console.error("Error deleting board:", error);
+          setIsDeleteDialogOpen(false);
         }
       };
 

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -9,6 +9,7 @@ import { withAITracking } from '@microsoft/applicationinsights-react-js';
 import { appInsights, reactPlugin, TelemetryEvents } from '../utilities/telemetryClient';
 import { DefaultButton, Dialog, DialogContent, DialogFooter, DialogType, PrimaryButton, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import { flexRender, useReactTable } from '@tanstack/react-table';
+import { reflectBackendService } from "../dal/reflectBackendService";
 
 import {
   createColumnHelper,
@@ -306,16 +307,16 @@ function getTable(
       const handleConfirmDelete = async (selectedBoard: IBoardSummaryTableItem) => {
         try {
           await BoardDataService.deleteFeedbackBoard(selectedBoard.teamId, selectedBoard.id);
-          //reflectBackendService.broadcastDeletedBoard(selectedBoard.teamId, selectedBoard.id);
+          reflectBackendService.broadcastDeletedBoard(selectedBoard.teamId, selectedBoard.id);
 
           // Update local state to remove the deleted board from the table
           setTableData((prevData) => prevData.filter(board => board.id !== selectedBoard.id));
 
           // Track the event
-          //appInsights.trackEvent({
-          //  name: TelemetryEvents.FeedbackBoardDeleted,
-          //  properties: { boardId: selectedBoard.id }
-          //});
+          appInsights.trackEvent({
+            name: TelemetryEvents.FeedbackBoardDeleted,
+            properties: { boardId: selectedBoard.id }
+          });
 
         } catch (error) {
           console.error("Error deleting board:", error);

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -319,7 +319,7 @@ function getTable(
       };
 
       // DPH extend to project admin and org admin later
-      const isAuthorized = selectedBoard.ownerId === currentUser.id;
+      const isAuthorized = false; //selectedBoard.ownerId === currentUser.id;
       // DPH reset to true after test and implement later
 
 // DPH

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -294,7 +294,14 @@ function getTable(
     const selectedBoard = cellContext.row.original;
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-    const dialogMessage = `The retrospective board "${selectedBoard.boardName}" with ${selectedBoard.feedbackItemsCount} feedback items will be deleted.\n\nThis action is permanent and cannot be undone.`;
+//    const dialogMessage = `The retrospective board "${selectedBoard.boardName}" with ${selectedBoard.feedbackItemsCount} feedback item(s) will be deleted.\n\nThis action is permanent and cannot be undone.`;
+const dialogMessage = (
+  <>
+    <span>The retrospective board "{selectedBoard.boardName}" with {selectedBoard.feedbackItemsCount} feedback items will be deleted.</span>
+    <br />
+    <span style={{ fontStyle: 'italic' }}>This action is permanent and cannot be undone.</span>
+  </>
+);
 
     const handleTrashClick = (event: React.MouseEvent) => {
       event.stopPropagation(); // Prevent row expansion on click

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -350,8 +350,8 @@ function getTable(
               </p>
             </DialogContent>
             <DialogFooter>
-              <DefaultButton onClick={handleCancelDelete} text="Cancel" />
               <PrimaryButton onClick={() => handleConfirmDelete(selectedBoard)} text="Delete" />
+              <DefaultButton autoFocus onClick={handleCancelDelete} text="Cancel" />
             </DialogFooter>
           </Dialog>
         </>

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -279,18 +279,15 @@ function getTable(
           <i className="fas fa-trash-alt" style={{ color: 'white' }} title="Delete board"></i>
         </div>
       ),
-      cell: (cellContext: CellContext<IBoardSummaryTableItem, unknown>) => {
-        const { isArchived } = cellContext.row.original;
-        return isArchived ? (
-          <div
-            className="centered-cell trash-icon"
-            title="Delete board"
-            onClick={(event) => event.stopPropagation()} // Prevent row expansion
-          >
-            <i className="fas fa-trash-alt"></i>
-          </div>
-        ) : null;
-      },
+        cell: (cellContext) => (
+      <div
+        className="centered-cell trash-icon"
+        title="Delete board"
+        onClick={(event) => event.stopPropagation()} // Prevent row expansion on any click
+      >
+        {cellContext.row.original.isArchived && <i className="fas fa-trash-alt"></i>}
+      </div>
+      ),
       size: 45,
       enableSorting: false,
     })

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -192,6 +192,7 @@ function getTable(
   sortingState: SortingState,
   onSortingChange: OnChangeFn<SortingState>,
   onArchiveToggle: () => void,
+  isDataLoaded: boolean, // DPH if remove need to make other changes to expect only 5 arguments
   setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>
 ): Table<IBoardSummaryTableItem> {
   const columnHelper = createColumnHelper<IBoardSummaryTableItem>();

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -52,6 +52,7 @@ export interface IBoardSummaryTableItem {
   feedbackItemsCount: number;
   id: string; // Board ID
   teamId: string;
+  trash?: boolean; // DPH delete
 }
 
 export interface IBoardActionItemsData {
@@ -270,7 +271,25 @@ function getTable(
       header: 'Total Work Items',
       footer: defaultFooter,
       size: 110,
-    })
+    }),
+    // DPH delete
+    columnHelper.accessor('trash', {
+      header: '',
+      footer: () => '',
+      cell: (cellContext: CellContext<IBoardSummaryTableItem, unknown>) => {
+        const { isArchived } = cellContext.row.original;
+
+        // Show trash icon whenever isArchived is true (including after toggles)
+        return isArchived ? (
+          <span className="trash-icon">
+            <i className="fas fa-trash-alt"></i>
+          </span>
+        ) : null;
+      },
+      size: 35,
+      enableSorting: false,
+      enableResizing: false
+    }),
   ]
 
   const tableOptions: TableOptions<IBoardSummaryTableItem> = {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -152,18 +152,17 @@ const reloadBoardHistory = async (
   try {
     const updatedBoardData: IFeedbackBoardDocument[] = await BoardDataService.getBoardsForTeam(teamId);
 
-    // Convert `IFeedbackBoardDocument` to `IBoardSummaryTableItem`
-    const formattedData: IBoardSummaryTableItem[] = updatedBoardData.map(board => ({
-      id: board.id,
-      teamId: board.teamId,
-      boardName: board.boardName || "Untitled Board",
-      pendingWorkItemsCount: board.pendingWorkItemsCount ?? 0,
-      totalWorkItemsCount: board.totalWorkItemsCount ?? 0,
-      feedbackItemsCount: board.feedbackItemsCount ?? 0,
-      ownerId: board.ownerId || "Unknown Owner",
-      isArchived: board.isArchived ?? false,
-      createdDate: board.createdDate ?? new Date(), // ✅ Add `createdDate`
-    }));
+const formattedData: IBoardSummaryTableItem[] = updatedBoardData.map(board => ({
+  id: board.id,
+  teamId: board.teamId,
+  boardName: (board as any).boardName || "Untitled Board", 
+  createdDate: board.createdDate ? new Date(board.createdDate) : new Date(), 
+pendingWorkItemsCount: (board as any).pendingWorkItemsCount ?? 0,
+totalWorkItemsCount: (board as any).totalWorkItemsCount ?? 0,
+feedbackItemsCount: (board as any).feedbackItemsCount ?? 0,
+ownerId: (board as any).ownerId || "Unknown Owner",
+  isArchived: board.isArchived ?? false,
+}));
 
     setTableData(formattedData); // Now passing correctly formatted data
   } catch (error) {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -11,7 +11,7 @@ import { itemDataService } from '../dal/itemDataService';
 import { workItemService } from '../dal/azureDevOpsWorkItemService';
 import { reflectBackendService } from "../dal/reflectBackendService";
 import { appInsights, reactPlugin, TelemetryEvents } from '../utilities/telemetryClient';
-import { getUserIdentity } from '../utilities/userIdentityHelper';
+import { encrypt, getUserIdentity } from '../utilities/userIdentityHelper';
 
 import {
   createColumnHelper,
@@ -79,7 +79,7 @@ interface BoardSummaryTableBodyProps {
 }
 
 //DPH
-//const currentUser = getUserIdentity();
+const currentUserId = encrypt(getUserIdentity().id);
 
 const BoardSummaryTableHeader: React.FC<BoardSummaryTableHeaderProps> = ({ headerGroups, getThProps }) => (
   <thead role="rowgroup">
@@ -310,7 +310,11 @@ function getTable(
           // Track the event
           appInsights.trackEvent({
             name: TelemetryEvents.FeedbackBoardDeleted,
-            properties: { boardId: selectedBoard.id }
+            properties: { 
+              boardId: selectedBoard.id,
+              boardName: selectedBoard.boardName, // Assuming the board object has a 'name' property
+              deletedByUserId: currentUserId, // Ensure you have access to the current user
+            }
           });
 
         } catch (error) {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -604,7 +604,7 @@ function BoardSummaryTable(props: Readonly<IBoardSummaryTableProps>): JSX.Elemen
   }
 
   useEffect(() => {
-    if(teamId !== props.teamId) {
+    if(teamId !== props.teamId || refreshKey > 0) {
       BoardDataService.getBoardsForTeam(props.teamId).then((boardDocuments: IFeedbackBoardDocument[]) => {
         setTeamId(props.teamId);
         handleBoardsDocuments(boardDocuments);

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -191,9 +191,7 @@ function getTable(
   onArchiveToggle: () => void,
   // isDataLoaded: boolean, // DPH if remove then expect only 5 arguments
   setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>,
-  setRefreshKey: React.Dispatch<React.SetStateAction<boolean>>,
-  isDeleteDialogOpen: boolean,
-  setIsDeleteDialogOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setRefreshKey: React.Dispatch<React.SetStateAction<boolean>>
 ): Table<IBoardSummaryTableItem> {
   const columnHelper = createColumnHelper<IBoardSummaryTableItem>();
   const defaultFooter = (info: HeaderContext<IBoardSummaryTableItem, unknown>) => info.column.id;
@@ -288,7 +286,7 @@ function getTable(
       ),
       cell: (cellContext) => {
         const selectedBoard = cellContext.row.original;
-        //const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);  DPH
+        const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
         const handleTrashClick = (event: React.MouseEvent) => {
           event.stopPropagation(); // Prevent row expansion on click
@@ -409,15 +407,9 @@ function BoardSummaryTable(props: Readonly<IBoardSummaryTableProps>): JSX.Elemen
 
   // DPH
   const [refreshKey, setRefreshKey] = useState(false);
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false); // ✅ Move state to parent component
 
-  const table: Table<IBoardSummaryTableItem> = getTable(
-  tableData, sorting, setSorting, props.onArchiveToggle, setTableData, setRefreshKey,
-  isDeleteDialogOpen, setIsDeleteDialogOpen // ✅ Now passed as props
-);
-
-//  const table: Table<IBoardSummaryTableItem> =
-//   getTable(tableData, sorting, setSorting, props.onArchiveToggle, setTableData, setRefreshKey); // DPH boardSummaryState.isDataLoaded,
+  const table: Table<IBoardSummaryTableItem> =
+    getTable(tableData, sorting, setSorting, props.onArchiveToggle, setTableData, setRefreshKey); // DPH boardSummaryState.isDataLoaded,
 
   const updatedState: IBoardSummaryTableState = { ...boardSummaryState };
 

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -284,15 +284,18 @@ function getTable(
       cell: (cellContext: CellContext<IBoardSummaryTableItem, unknown>) => {
         const { isArchived } = cellContext.row.original;
         return isArchived ? (
-          <div className="centered-cell trash-icon" title="Delete board">
+          <div
+            className="centered-cell trash-icon"
+            title="Delete board"
+            onClick={(event) => event.stopPropagation()} // Prevent row expansion
+          >
             <i className="fas fa-trash-alt"></i>
           </div>
         ) : null;
       },
-      size: 40,
+      size: 45,
       enableSorting: false,
-      //enableResizing: false
-    }),
+    });
   ]
 
   const tableOptions: TableOptions<IBoardSummaryTableItem> = {

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -313,22 +313,10 @@ function getTable(
               deletedByUserId: encrypt(getUserIdentity().id),
             }
           });
-        }
-        catch (error: unknown) {
-  if (error instanceof Error && 'response' in error && (error.response as { status?: number }).status === 404) {
-    // Board already deleted, just update the table and close the dialog
-    setIsDeleteDialogOpen(false);
-    console.log("Caught the 404.");
-    setTableData(prevData => prevData.filter(board => board.id !== selectedBoard.id));
-  } else {
-    console.error("Error deleting board:", error);
-  }
-}
-/* catch (error) {
+
+        } catch (error) {
           console.error("Error deleting board:", error);
-          BoardDataService.getBoardsForTeam(props.teamId).then(handleBoardsDocuments);
         }
-*/
       };
 
 // DPH

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -191,7 +191,9 @@ function getTable(
   onArchiveToggle: () => void,
   // isDataLoaded: boolean, // DPH if remove then expect only 5 arguments
   setTableData: React.Dispatch<React.SetStateAction<IBoardSummaryTableItem[]>>,
-  setRefreshKey: React.Dispatch<React.SetStateAction<boolean>>
+  setRefreshKey: React.Dispatch<React.SetStateAction<boolean>>,
+  isDeleteDialogOpen: boolean,
+  setIsDeleteDialogOpen: React.Dispatch<React.SetStateAction<boolean>>
 ): Table<IBoardSummaryTableItem> {
   const columnHelper = createColumnHelper<IBoardSummaryTableItem>();
   const defaultFooter = (info: HeaderContext<IBoardSummaryTableItem, unknown>) => info.column.id;
@@ -286,7 +288,7 @@ function getTable(
       ),
       cell: (cellContext) => {
         const selectedBoard = cellContext.row.original;
-        const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+        //const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);  DPH
 
         const handleTrashClick = (event: React.MouseEvent) => {
           event.stopPropagation(); // Prevent row expansion on click
@@ -407,9 +409,15 @@ function BoardSummaryTable(props: Readonly<IBoardSummaryTableProps>): JSX.Elemen
 
   // DPH
   const [refreshKey, setRefreshKey] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false); // ✅ Move state to parent component
 
-  const table: Table<IBoardSummaryTableItem> =
-    getTable(tableData, sorting, setSorting, props.onArchiveToggle, setTableData, setRefreshKey); // DPH boardSummaryState.isDataLoaded,
+  const table: Table<IBoardSummaryTableItem> = getTable(
+  tableData, sorting, setSorting, props.onArchiveToggle, setTableData, setRefreshKey,
+  isDeleteDialogOpen, setIsDeleteDialogOpen // ✅ Now passed as props
+);
+
+//  const table: Table<IBoardSummaryTableItem> =
+//   getTable(tableData, sorting, setSorting, props.onArchiveToggle, setTableData, setRefreshKey); // DPH boardSummaryState.isDataLoaded,
 
   const updatedState: IBoardSummaryTableState = { ...boardSummaryState };
 

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -3,7 +3,6 @@ import { WorkItem, WorkItemType, WorkItemStateColor } from 'azure-devops-extensi
 import { DefaultButton, Dialog, DialogContent, DialogFooter, DialogType, PrimaryButton, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import { withAITracking } from '@microsoft/applicationinsights-react-js';
 import { flexRender, useReactTable } from '@tanstack/react-table';
-
 import BoardSummary from './boardSummary';
 import { IFeedbackBoardDocument } from '../interfaces/feedback';
 import BoardDataService from '../dal/boardDataService';

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -3,6 +3,7 @@ import { WorkItem, WorkItemType, WorkItemStateColor } from 'azure-devops-extensi
 import { DefaultButton, Dialog, DialogContent, DialogFooter, DialogType, PrimaryButton, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import { withAITracking } from '@microsoft/applicationinsights-react-js';
 import { flexRender, useReactTable } from '@tanstack/react-table';
+
 import BoardSummary from './boardSummary';
 import { IFeedbackBoardDocument } from '../interfaces/feedback';
 import BoardDataService from '../dal/boardDataService';

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -318,17 +318,13 @@ function getTable(
         }
       };
 
-      // DPH refactor to restrict to board owner, project admin, and org admin
-      const isAuthorized = true;
-
 // DPH
       return (
         <>
           <div
             className="centered-cell trash-icon"
             title="Delete board"
-            onClick={isAuthorized ? handleTrashClick : undefined}
-            style={{ opacity: isAuthorized ? 1 : 0.5, pointerEvents: isAuthorized ? "auto" : "none" }}
+            onClick={handleTrashClick}
           >
             {selectedBoard.isArchived && <i className="fas fa-trash-alt"></i>}
           </div>

--- a/src/frontend/components/boardSummaryTable.tsx
+++ b/src/frontend/components/boardSummaryTable.tsx
@@ -79,7 +79,7 @@ interface BoardSummaryTableBodyProps {
 }
 
 //DPH
-const currentUser = getUserIdentity();
+//const currentUser = getUserIdentity();
 
 const BoardSummaryTableHeader: React.FC<BoardSummaryTableHeaderProps> = ({ headerGroups, getThProps }) => (
   <thead role="rowgroup">
@@ -318,9 +318,8 @@ function getTable(
         }
       };
 
-      // DPH extend to project admin and org admin later
-      const isAuthorized = false; //selectedBoard.ownerId === currentUser.id;
-      // DPH reset to true after test and implement later
+      // DPH refactor to restrict to board owner, project admin, and org admin
+      const isAuthorized = true;
 
 // DPH
       return (

--- a/src/frontend/components/effectivenessMeasurementRow.tsx
+++ b/src/frontend/components/effectivenessMeasurementRow.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 
 import { encrypt, getUserIdentity } from '../utilities/userIdentityHelper';
-
 import { ITeamEffectivenessMeasurementVoteCollection } from '../interfaces/feedback';
 
 export interface EffectivenessMeasurementRowProps {

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1731,6 +1731,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                   teamId={this.state.currentTeam.id}
                   supportedWorkItemTypes={this.state.allWorkItemTypes}
                   onArchiveToggle={this.handleArchiveToggle}
+                  showDeleteBoardConfirmationDialog={this.showDeleteBoardConfirmationDialog} // ✅ Pass delete function
                 />
               </div>
             </PivotItem>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -80,7 +80,7 @@ export interface FeedbackBoardContainerState {
   isBoardCreationDialogHidden: boolean;
   isBoardDuplicateDialogHidden: boolean;
   isBoardUpdateDialogHidden: boolean;
-  isArchiveBoardConfirmationDialogHidden: boolean;
+//  isArchiveBoardConfirmationDialogHidden: boolean;
 //  isDeleteBoardConfirmationDialogHidden: boolean;
   isMobileBoardActionsDialogHidden: boolean;
   isMobileTeamSelectorDialogHidden: boolean;
@@ -135,7 +135,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       isCarouselDialogHidden: true,
       isIncludeTeamEffectivenessMeasurementDialogHidden: true,
       isPrimeDirectiveDialogHidden: true,
-      isArchiveBoardConfirmationDialogHidden: true,
+//      isArchiveBoardConfirmationDialogHidden: true,
 //      isDeleteBoardConfirmationDialogHidden: true,
       isDesktop: true,
       isDropIssueInEdgeMessageBarVisible: true,
@@ -981,7 +981,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
   private readonly hideDeleteBoardConfirmationDialog = () => {
     this.setState({ isDeleteBoardConfirmationDialogHidden: true });
   }
-*/
+
   private readonly showArchiveBoardConfirmationDialog = () => {
     this.setState({ isArchiveBoardConfirmationDialogHidden: false });
   }
@@ -989,7 +989,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
   private readonly hideArchiveBoardConfirmationDialog = () => {
     this.setState({ isArchiveBoardConfirmationDialogHidden: true });
   }
-/* DPH
+
   private readonly hideTeamBoardDeletedInfoDialog = () => {
     this.setState(
       {
@@ -1019,14 +1019,14 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
 
     this.setState({ isReconnectingToBackendService: false });
   }
-
+/* DPH
   private readonly archiveCurrentBoard = async () => {
     await BoardDataService.archiveFeedbackBoard(this.state.currentTeam.id, this.state.currentBoard.id);
     reflectBackendService.broadcastDeletedBoard(this.state.currentTeam.id, this.state.currentBoard.id);
     this.hideArchiveBoardConfirmationDialog();
     appInsights.trackEvent({ name: TelemetryEvents.FeedbackBoardArchived, properties: { boardId: this.state.currentBoard.id } });
   }
-/* DPH
+
   private readonly deleteCurrentBoard = async () => {
     await BoardDataService.deleteFeedbackBoard(this.state.currentTeam.id, this.state.currentBoard.id);
     reflectBackendService.broadcastDeletedBoard(this.state.currentTeam.id, this.state.currentBoard.id);
@@ -1191,6 +1191,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       key: 'seperator',
       itemType: ContextualMenuItemType.Divider,
     },
+/* DPH
     {
       key: 'archiveBoard',
       iconProps: { iconName: 'Archive' },
@@ -1198,7 +1199,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       text: 'Archive retrospective',
       title: 'Archive retrospective',
     },
-/*    {
+    {
       key: 'deleteBoard',
       iconProps: { iconName: 'Delete' },
       onClick: this.showDeleteBoardConfirmationDialog,
@@ -1699,7 +1700,6 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                       <DefaultButton onClick={this.hideremoConfirmationDialog} text="Cancel" />
                     </DialogFooter>
                   </Dialog>
-*/}
                   <Dialog
                     hidden={this.state.isArchiveBoardConfirmationDialogHidden}
                     onDismiss={this.hideArchiveBoardConfirmationDialog}
@@ -1724,6 +1724,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                       <DefaultButton onClick={this.hideArchiveBoardConfirmationDialog} text="Cancel" />
                     </DialogFooter>
                   </Dialog>
+*/}
                 </div>
               }
             </PivotItem>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1697,7 +1697,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                     }}>
                     <DialogFooter>
                       <PrimaryButton onClick={this.deleteCurrentBoard} text="Delete" />
-                      <DefaultButton onClick={this.hideremoConfirmationDialog} text="Cancel" />
+                      <DefaultButton onClick={this.hideDeleteBoardConfirmationDialog} text="Cancel" />
                     </DialogFooter>
                   </Dialog>
                   <Dialog

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1731,7 +1731,6 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                   teamId={this.state.currentTeam.id}
                   supportedWorkItemTypes={this.state.allWorkItemTypes}
                   onArchiveToggle={this.handleArchiveToggle}
-                  showDeleteBoardConfirmationDialog={this.showDeleteBoardConfirmationDialog} // ✅ Pass delete function
                 />
               </div>
             </PivotItem>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1914,6 +1914,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             </>
           }
         </Dialog>
+{/* DPH
         <Dialog
           hidden={this.state.isTeamBoardDeletedInfoDialogHidden}
           onDismiss={this.hideTeamBoardDeletedInfoDialog}
@@ -1931,6 +1932,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
             <DefaultButton aria-label="Dismiss Deleted Team Board Dialog" onClick={this.hideTeamBoardDeletedInfoDialog} text="Dismiss" />
           </DialogFooter>
         </Dialog>
+*/}
         <ToastContainer
           transition={Slide}
           closeButton={false}

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -81,7 +81,7 @@ export interface FeedbackBoardContainerState {
   isBoardDuplicateDialogHidden: boolean;
   isBoardUpdateDialogHidden: boolean;
   isArchiveBoardConfirmationDialogHidden: boolean;
-  isDeleteBoardConfirmationDialogHidden: boolean;
+//  isDeleteBoardConfirmationDialogHidden: boolean;
   isMobileBoardActionsDialogHidden: boolean;
   isMobileTeamSelectorDialogHidden: boolean;
   isTeamBoardDeletedInfoDialogHidden: boolean;
@@ -136,7 +136,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       isIncludeTeamEffectivenessMeasurementDialogHidden: true,
       isPrimeDirectiveDialogHidden: true,
       isArchiveBoardConfirmationDialogHidden: true,
-      isDeleteBoardConfirmationDialogHidden: true,
+//      isDeleteBoardConfirmationDialogHidden: true,
       isDesktop: true,
       isDropIssueInEdgeMessageBarVisible: true,
       isLiveSyncInTfsIssueMessageBarVisible: true,
@@ -973,7 +973,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
 
     return this.state.currentBoard.activePhase;
   }
-
+/* DPH
   private readonly showDeleteBoardConfirmationDialog = () => {
     this.setState({ isDeleteBoardConfirmationDialogHidden: false });
   }
@@ -981,7 +981,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
   private readonly hideDeleteBoardConfirmationDialog = () => {
     this.setState({ isDeleteBoardConfirmationDialogHidden: true });
   }
-
+*/
   private readonly showArchiveBoardConfirmationDialog = () => {
     this.setState({ isArchiveBoardConfirmationDialogHidden: false });
   }
@@ -989,7 +989,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
   private readonly hideArchiveBoardConfirmationDialog = () => {
     this.setState({ isArchiveBoardConfirmationDialogHidden: true });
   }
-
+/* DPH
   private readonly hideTeamBoardDeletedInfoDialog = () => {
     this.setState(
       {
@@ -999,7 +999,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       }
     );
   }
-
+*/
   private readonly showBoardUrlCopiedToast = () => {
     toast(`The link to retrospective ${this.state.currentBoard.title} has been copied to your clipboard.`);
   }
@@ -1026,7 +1026,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
     this.hideArchiveBoardConfirmationDialog();
     appInsights.trackEvent({ name: TelemetryEvents.FeedbackBoardArchived, properties: { boardId: this.state.currentBoard.id } });
   }
-
+/* DPH
   private readonly deleteCurrentBoard = async () => {
     await BoardDataService.deleteFeedbackBoard(this.state.currentTeam.id, this.state.currentBoard.id);
     reflectBackendService.broadcastDeletedBoard(this.state.currentTeam.id, this.state.currentBoard.id);
@@ -1034,7 +1034,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
     this.hideDeleteBoardConfirmationDialog();
     appInsights.trackEvent({ name: TelemetryEvents.FeedbackBoardDeleted, properties: { boardId: this.state.currentBoard.id } });
   }
-
+*/
   private readonly copyBoardUrl = async () => {
     const boardDeepLinkUrl = await getBoardUrl(this.state.currentTeam.id, this.state.currentBoard.id);
     copyToClipboard(boardDeepLinkUrl);
@@ -1198,13 +1198,13 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
       text: 'Archive retrospective',
       title: 'Archive retrospective',
     },
-    {
+/*    {
       key: 'deleteBoard',
       iconProps: { iconName: 'Delete' },
       onClick: this.showDeleteBoardConfirmationDialog,
       text: 'Delete retrospective',
       title: 'Delete retrospective',
-    },
+    }, */
   ];
 
   private readonly hideMobileBoardActionsDialog = () => {
@@ -1680,6 +1680,7 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                       userId={this.state.currentUserId}
                     />
                   </div>
+{/* DPH
                   <Dialog
                     hidden={this.state.isDeleteBoardConfirmationDialogHidden}
                     onDismiss={this.hideDeleteBoardConfirmationDialog}
@@ -1695,9 +1696,10 @@ class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps
                     }}>
                     <DialogFooter>
                       <PrimaryButton onClick={this.deleteCurrentBoard} text="Delete" />
-                      <DefaultButton onClick={this.hideDeleteBoardConfirmationDialog} text="Cancel" />
+                      <DefaultButton onClick={this.hideremoConfirmationDialog} text="Cancel" />
                     </DialogFooter>
                   </Dialog>
+*/}
                   <Dialog
                     hidden={this.state.isArchiveBoardConfirmationDialogHidden}
                     onDismiss={this.hideArchiveBoardConfirmationDialog}

--- a/src/frontend/css/boardSummary.scss
+++ b/src/frontend/css/boardSummary.scss
@@ -266,6 +266,17 @@
     color: var(--status-warning-text);
     font-weight: 600;
   }
+
+  .trash-icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .trash-icon:hover {
+    color: red; /* Highlight red on hover */
+  }
 }
 
 .board-summary-initialization-spinner {

--- a/src/frontend/dal/boardDataService.tsx
+++ b/src/frontend/dal/boardDataService.tsx
@@ -82,7 +82,7 @@ class BoardDataService {
     return await readDocument<IFeedbackBoardDocument>(teamId, boardId);
   }
 
-  public DPH_deleteFeedbackBoard = async (teamId: string, boardId: string) => {
+  public deleteFeedbackBoard = async (teamId: string, boardId: string) => {
     // Delete all documents in this board's collection.
     const boardItems = await readDocuments<IFeedbackItemDocument>(boardId);
     if (boardItems && boardItems.length) {
@@ -93,25 +93,6 @@ class BoardDataService {
 
     await deleteDocument(teamId, boardId);
   }
-
-public async deleteFeedbackBoard(teamId: string, boardId: string): Promise<boolean> {
-  const board = await this.getBoardForTeamById(teamId, boardId);
-  if (!board) {
-    console.log(`Board ${boardId} was already deleted.`);
-    return false;
-  }
-
-  // Retrieve associated board items
-  const boardItems = await readDocuments<IFeedbackItemDocument>(boardId);
-  if (boardItems.length) {
-    await Promise.all(boardItems.map(item => deleteDocument(boardId, item.id))); // Ensure deletions complete
-  }
-
-  // Delete the board itself
-  await deleteDocument(teamId, boardId);
-
-  return true; // Indicate successful deletion
-}
 
   public archiveFeedbackBoard = async (teamId: string, boardId: string) => {
     const board: IFeedbackBoardDocument = await this.getBoardForTeamById(teamId, boardId);

--- a/src/frontend/dal/boardDataService.tsx
+++ b/src/frontend/dal/boardDataService.tsx
@@ -82,7 +82,7 @@ class BoardDataService {
     return await readDocument<IFeedbackBoardDocument>(teamId, boardId);
   }
 
-  public deleteFeedbackBoard = async (teamId: string, boardId: string) => {
+  public DPH_deleteFeedbackBoard = async (teamId: string, boardId: string) => {
     // Delete all documents in this board's collection.
     const boardItems = await readDocuments<IFeedbackItemDocument>(boardId);
     if (boardItems && boardItems.length) {
@@ -93,6 +93,19 @@ class BoardDataService {
 
     await deleteDocument(teamId, boardId);
   }
+
+  public deleteFeedbackBoard = async (teamId: string, boardId: string): Promise<boolean> => {
+    const board = await this.getBoardForTeamById(teamId, boardId);
+    if (!board) {
+      console.log(`Board ${boardId} was already deleted.`);
+      return false; // Indicate that the board was already gone
+    }
+
+    // Delete board document
+    await deleteDocument(teamId, boardId);
+
+    return true; // Successful deletion
+  };
 
   public archiveFeedbackBoard = async (teamId: string, boardId: string) => {
     const board: IFeedbackBoardDocument = await this.getBoardForTeamById(teamId, boardId);


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #787 and #778

## Description

Add delete after archive from history tab. Goal is to create a "safer" delete by first requiring the user to archive.  

Functionality will be similar to how delete often moves a work item to the trash bin, and then once in trash bin user can restore or permanently delete.  In this case Archive will remove the board from the dropdown, and then the user can restore the archive or choose to permanently delete.

## Bug or Feature?

- [ ] Bug fix
- [x] New feature