### PR TITLE
Revert azure-devops-extension-api to prior version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "vsts-extension-retrospectives",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@microsoft/applicationinsights-web": "3.3.6",
         "@microsoft/signalr": "8.0.7",
         "@tanstack/react-table": "8.20.5",
-        "azure-devops-extension-api": "4.254.0",
+        "azure-devops-extension-api": "1.152.0",
         "azure-devops-extension-sdk": "2.0.11",
         "classnames": "2.5.1",
         "copy-to-clipboard": "3.3.3",
@@ -4510,15 +4510,13 @@
       }
     },
     "node_modules/azure-devops-extension-api": {
-      "version": "4.254.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-extension-api/-/azure-devops-extension-api-4.254.0.tgz",
-      "integrity": "sha512-4R4wDF9h9DHd2ESY5iSCvNrvZkiAHHxUXq9zpjIyYaQS01qkBRK7e1j314yZDFkTZNzQdOYnkmoDQBN+00qzfQ==",
+      "version": "1.152.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-extension-api/-/azure-devops-extension-api-1.152.0.tgz",
+      "integrity": "sha512-SqXmTUZ+oJ2XM9q74uVTrBkxRSsnIkROjr6bV4bECwVnNtsyI0X2FZExXrVXmYzRXhPuL6cbm6Y1xHvd15n5/A==",
       "license": "MIT",
       "dependencies": {
+        "azure-devops-extension-sdk": "~2.0.6",
         "whatwg-fetch": "~3.0.0"
-      },
-      "peerDependencies": {
-        "azure-devops-extension-sdk": "^2 || ^3 || ^4"
       }
     },
     "node_modules/azure-devops-extension-sdk": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -31,7 +31,7 @@
     "@microsoft/applicationinsights-web": "3.3.6",
     "@microsoft/signalr": "8.0.7",
     "@tanstack/react-table": "8.20.5",
-    "azure-devops-extension-api": "4.254.0",
+    "azure-devops-extension-api": "1.152.0",
     "azure-devops-extension-sdk": "2.0.11",
     "classnames": "2.5.1",
     "copy-to-clipboard": "3.3.3",


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #1276

## Description

Revert azure-devops-extension-api to prior version to be compatible with on-prem version.

## Bug or Feature?

- [x] Bug fix
- [ ] New feature
