### PR TITLE
Correct handling after confirming okay to delete column

### DIFF
--- a/src/frontend/components/__tests__/feedbackBoardMetadataForm.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataForm.test.tsx
@@ -4,7 +4,6 @@ import { mockUuid } from '../__mocks__/uuid/v4';
 import FeedbackBoardMetadataForm, { IFeedbackBoardMetadataFormProps, IFeedbackColumnCard } from '../feedbackBoardMetadataForm';
 import { testColumns, testExistingBoard, testTeamId } from '../__mocks__/mocked_components/mockedBoardMetadataForm';
 import { Checkbox, List, TextField } from 'office-ui-fabric-react';
-import BoardDataService from '../../dal/boardDataService';
 
 const mockedProps: IFeedbackBoardMetadataFormProps = {
   isNewBoardCreation: true,
@@ -238,54 +237,4 @@ describe('Board Metadata Form', () => {
     });
   })
 
-  describe('Simulate Defect', () => {
-
-    it('removes marked column and closes dialog when Confirm is clicked', async () => {
-      // Arrange: Mock board name check to avoid real data service call
-      jest.spyOn(BoardDataService, 'checkIfBoardNameIsTaken').mockResolvedValue(false);
-
-      const onFormSubmit = jest.fn();
-      const mockBoard = { ...testExistingBoard };
-
-      const mockProps = {
-        ...mockedProps,
-        isNewBoardCreation: false,
-        currentBoard: mockBoard,
-        onFormSubmit,
-      };
-
-      const wrapper = shallow(<FeedbackBoardMetadataForm {...mockProps} />);
-      const component = wrapper.children().dive();
-
-      // Mark the first column for deletion
-      const columns = component.state('columnCards') as IFeedbackColumnCard[];
-      const deletedColumnId = columns[0].column.id;
-
-      const updatedColumns = columns.map((col, idx) =>
-        idx === 0 ? { ...col, markedForDeletion: true } : col
-      );
-
-      component.setState({
-        columnCards: updatedColumns,
-        isDeleteColumnConfirmationDialogHidden: false,
-      });
-
-      // Act:
-      // Simulate click on Confirm by calling the handler directly
-      const fakeEvent = { preventDefault: () => {}, stopPropagation: () => {} } as any;
-
-      // Call handleFormSubmit directly (this is what Confirm button used to call)
-      await (component.instance() as any).handleFormSubmit(fakeEvent);
-
-      // Assert: Dialog closes
-      expect(component.state('isDeleteColumnConfirmationDialogHidden')).toBe(true);
-
-      // Assert: onFormSubmit called
-      expect(onFormSubmit).toHaveBeenCalled();
-
-      // Assert: Deleted column is not passed through
-      const submittedColumns = onFormSubmit.mock.calls[0][2];
-      expect(submittedColumns.find((col: any) => col.id === deletedColumnId)).toBeUndefined();
-    });
-  });
 });

--- a/src/frontend/components/__tests__/feedbackBoardMetadataForm.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataForm.test.tsx
@@ -270,11 +270,12 @@ describe('Board Metadata Form', () => {
         isDeleteColumnConfirmationDialogHidden: false,
       });
 
-      // Act: Call the old handleFormSubmit directly (which is what the old code did)
-      await (component.instance() as any).handleFormSubmit({
-        preventDefault: () => {},
-        stopPropagation: () => {},
-      });
+      // Act:
+      // Simulate click on Confirm by calling the handler directly
+      const fakeEvent = { preventDefault: () => {}, stopPropagation: () => {} } as any;
+
+      // Call handleFormSubmit directly (this is what Confirm button used to call)
+      await (component.instance() as any).handleFormSubmit(fakeEvent);
 
       // Assert: Dialog closes
       expect(component.state('isDeleteColumnConfirmationDialogHidden')).toBe(true);

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -145,6 +145,12 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
     });
   }
 
+  handleDeleteColumnConfirm = (event: any) => {
+    this.setState({ isDeleteColumnConfirmationDialogHidden: true }, () => {
+      this.handleFormSubmit(event);
+    });
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async handleFormSubmit(event: any) {
     event.preventDefault();
@@ -600,7 +606,7 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
                   className: 'retrospectives-dialog-modal',
                 }}>
                 <DialogFooter>
-                  <PrimaryButton onClick={this.handleFormSubmit} text="Confirm" />
+                  <PrimaryButton onClick={this.handleDeleteColumnConfirm} text="Confirm" />
                   <DefaultButton onClick={this.hideDeleteColumnConfirmationDialog} text="Cancel" />
                 </DialogFooter>
               </Dialog>}

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -145,12 +145,14 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
     });
   }
 
-  handleDeleteColumnConfirm = (event: React.FormEvent<HTMLFormElement>) => {
-  //handleDeleteColumnConfirm = (event: any) => {
-    this.setState({ isDeleteColumnConfirmationDialogHidden: true }, () => {
-      this.handleFormSubmit(event);
-    });
-  }
+handleDeleteColumnConfirm = (event: React.MouseEvent<HTMLButtonElement>) => {
+  event.preventDefault(); // Optional, depending on usage
+  event.stopPropagation();
+
+  this.setState({ isDeleteColumnConfirmationDialogHidden: true }, () => {
+    this.handleFormSubmit(event); // Now passes MouseEvent
+  });
+}
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async handleFormSubmit(event: any) {

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -145,8 +145,8 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handleDeleteColumnConfirm = (event: any) => {
+  handleDeleteColumnConfirm = (event: React.FormEvent<HTMLFormElement>) => {
+  //handleDeleteColumnConfirm = (event: any) => {
     this.setState({ isDeleteColumnConfirmationDialogHidden: true }, () => {
       this.handleFormSubmit(event);
     });

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -145,17 +145,17 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
     });
   }
 
-handleDeleteColumnConfirm = (event: React.MouseEvent<HTMLButtonElement>) => {
-  event.preventDefault(); // Optional, depending on usage
-  event.stopPropagation();
+  handleDeleteColumnConfirm = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault(); // Optional, depending on usage
+    event.stopPropagation();
 
-  this.setState({ isDeleteColumnConfirmationDialogHidden: true }, () => {
-    this.handleFormSubmit(event); // Now passes MouseEvent
-  });
-}
+    this.setState({ isDeleteColumnConfirmationDialogHidden: true }, () => {
+      this.handleFormSubmit(event); // Now passes MouseEvent
+    });
+  }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async handleFormSubmit(event: any) {
+  // Accept either MouseEvent or FormEvent
+  public async handleFormSubmit(event: React.SyntheticEvent) {
     event.preventDefault();
     event.stopPropagation();
 

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -153,9 +153,9 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async handleFormSubmit(event: any) {
-    event.preventDefault();
-    event.stopPropagation();
+  public async handleFormSubmit(event?: any) {
+    event?.preventDefault();
+    event?.stopPropagation();
 
     if (this.state.title.trim() === '') return;
 

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -146,7 +146,7 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
   }
 
   handleDeleteColumnConfirm = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault(); // Optional, depending on usage
+    event.preventDefault();
     event.stopPropagation();
 
     this.setState({ isDeleteColumnConfirmationDialogHidden: true }, () => {
@@ -155,7 +155,9 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
   }
 
   // Accept either MouseEvent or FormEvent
-  public async handleFormSubmit(event: React.SyntheticEvent) {
+  public async handleFormSubmit(
+    event: Pick<React.SyntheticEvent, 'preventDefault' | 'stopPropagation'>
+  ) {
     event.preventDefault();
     event.stopPropagation();
 

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -145,6 +145,7 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handleDeleteColumnConfirm = (event: any) => {
     this.setState({ isDeleteColumnConfirmationDialogHidden: true }, () => {
       this.handleFormSubmit(event);

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -153,9 +153,9 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async handleFormSubmit(event?: any) {
-    event?.preventDefault();
-    event?.stopPropagation();
+  public async handleFormSubmit(event: any) {
+    event.preventDefault();
+    event.stopPropagation();
 
     if (this.state.title.trim() === '') return;
 


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #1283

## Description

When user marks column for deletion and clicks save, a confirmation dialog box opens and no action occurs when clicking Confirm.  

## Bug or Feature?

- [x] Bug fix
- [ ] New feature
