### PR TITLE
identify groups by pattern and remove them from permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ You can find the changelog of the Retrospective Extension below.
 
 ## v1.92.45
 
-* Reverted azure-devops-extension-api to prior version to be compatible with older on-prem version. From [GitHub PR #1282](https://github.com/microsoft/vsts-extension-retrospectives/pull/1282)
+* Reverted Azure DevOps extension API to prior version to be compatible with older on-premise version. From [GitHub PR #1282](https://github.com/microsoft/vsts-extension-retrospectives/pull/1282)
 
 ## v1.92.43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 You can find the changelog of the Retrospective Extension below.
 
+## v1.92.[TBD]
+
+* Removes groups from Permission table, since setting permission by groups not supported. From [GitHub PR #1294](https://github.com/microsoft/vsts-extension-retrospectives/pull/1294)
+
+## v1.92.46
+
+* Corrected defect preventing user from saving after marking column for deletion. From [GitHub PR #1284](https://github.com/microsoft/vsts-extension-retrospectives/pull/1284)
+
+## v1.92.45
+
+* Reverted azure-devops-extension-api to prior version to be compatible with older on-prem version. From [GitHub PR #1282](https://github.com/microsoft/vsts-extension-retrospectives/pull/1282)
+
 ## v1.92.43
 
 * Refactored the Retrospective Extension settings menu to more closely mirror the ADO menus format.

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -761,6 +761,45 @@ describe('Select Permissions', () => {
     expect(lastCall.permissions.Teams).not.toContain('team-1');
   });
 
+  it('removes all filtered permissions when Select All is unchecked', () => {
+  const initialTeams = ['team-1', 'team-2'];
+  const initialMembers = ['user-1', 'user-2'];
+
+  const props = makeProps({
+    permissions: {
+      Teams: initialTeams,
+      Members: initialMembers,
+    },
+    currentUserId: 'user-1', // board owner to allow edits
+  });
+
+  const wrapper = shallow(<FeedbackBoardMetadataFormPermissions {...props} />);
+  const component = wrapper.dive();
+
+  // Set initial state manually for test
+  component.setState({
+    teamPermissions: initialTeams,
+    memberPermissions: initialMembers,
+    filteredPermissionOptions: [
+      { id: 'team-1', type: 'team', name: 'Team 1' },
+      { id: 'user-1', type: 'member', name: 'User 1' }
+    ]
+  });
+
+  const instance = component.instance() as any;
+
+  // Call handleSelectAllClicked with false to uncheck "Select All"
+  instance.handleSelectAllClicked(false);
+
+  // After unchecking, all filtered permissions should be removed
+  expect(component.state('teamPermissions')).not.toContain('team-1');
+  expect(component.state('memberPermissions')).not.toContain('user-1');
+
+  // The other permissions not in filteredPermissionOptions should remain
+  expect(component.state('teamPermissions')).toContain('team-2');
+  expect(component.state('memberPermissions')).toContain('user-2');
+});
+
   describe('Board Owner Row Rendering', () => {
     it('should show the current user as board owner when creating a new board or copying a board (isNewBoardCreation: true)', () => {
       const props = makeProps({

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -773,22 +773,28 @@ describe('Search and Filtering', () => {
 
     const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-    // Trigger the Fabric TextField's onChange manually
-    wrapper.find(TextField).prop('onChange')!(undefined as any, 'alpha');
+    // Initial state: group should be filtered out
+    let visibleRows = wrapper.find('tr.option-row');
+    expect(visibleRows).toHaveLength(2);
+    expect(visibleRows.at(0).text()).toContain('Team Alpha');
+    expect(visibleRows.at(1).text()).toContain('User Beta');
+
+    // Simulate entering 'beta' in search input
+    wrapper.find(TextField).prop('onChange')?.(undefined as any, 'beta');
     wrapper.update();
 
-    let rows = wrapper.find('tbody tr.option-row');
-    expect(rows.length).toBe(1);
-    expect(rows.at(0).text()).toContain('Team Alpha');
+    visibleRows = wrapper.find('tr.option-row');
+    expect(visibleRows).toHaveLength(1);
+    expect(visibleRows.at(0).text()).toContain('User Beta');
 
-    // Clear search input
-    wrapper.find(TextField).prop('onChange')!(undefined as any, '');
-    wrapper.update();
+    // Clear the search input
+wrapper.find(TextField).prop('onChange')!({ target: { value: '' } } as any);
+wrapper.update();
 
-    rows = wrapper.find('tbody tr.option-row');
-    expect(rows.length).toBe(2); // Group is still filtered out
-    expect(rows.at(0).text()).toContain('Team Alpha');
-    expect(rows.at(1).text()).toContain('User Beta');
+    visibleRows = wrapper.find('tr.option-row');
+    expect(visibleRows).toHaveLength(2);
+    expect(visibleRows.at(0).text()).toContain('Team Alpha');
+    expect(visibleRows.at(1).text()).toContain('User Beta');
   });
 });
 

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -721,44 +721,81 @@ describe('Board Metadata Form Permissions', () => {
       expect(onPermissionChanged).not.toHaveBeenCalled();
     });
   });
-});
 
-describe('Select Permissions', () => {
-  it('should grant permission to all when select all is clicked and saved', async () => {
-    const onPermissionChanged = jest.fn();
-    const props = makeProps({ onPermissionChanged, currentUserId: 'user-1', isNewBoardCreation: true, board: { ...mockedProps.board, createdBy: { ...mockedProps.board.createdBy, id: 'user-3' } } });
-    const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
-    wrapper.find('input#select-all-permission-options-visible').simulate('change', { target: { checked: true } });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const lastCall = onPermissionChanged.mock.calls[onPermissionChanged.mock.calls.length - 1][0];
-    expect(lastCall.permissions.Teams).toEqual(expect.arrayContaining(['team-1']));
-    expect(lastCall.permissions.Members).toEqual(expect.arrayContaining(['user-1', 'user-2', 'user-3']));
-  });
+  describe('Select Permissions', () => {
+    it('should grant permission to all when select all is clicked and saved', async () => {
+      const onPermissionChanged = jest.fn();
+      const props = makeProps({
+        onPermissionChanged,
+        currentUserId: 'user-1',
+        isNewBoardCreation: true,
+        board: { ...mockedProps.board, createdBy: { ...mockedProps.board.createdBy, id: 'user-3' } }
+      });
+      const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
+      wrapper.find('input#select-all-permission-options-visible').simulate('change', { target: { checked: true } });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const lastCall = onPermissionChanged.mock.calls[onPermissionChanged.mock.calls.length - 1][0];
+      expect(lastCall.permissions.Teams).toEqual(expect.arrayContaining(['team-1']));
+      expect(lastCall.permissions.Members).toEqual(expect.arrayContaining(['user-1', 'user-2', 'user-3']));
+    });
 
-  it('should grant permission to the selected team and the board owner only when team is selected and saved', async () => {
-    const onPermissionChanged = jest.fn();
-    const props = makeProps({ onPermissionChanged });
-    const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
-    wrapper.find('input#permission-option-team-1').simulate('change', { target: { checked: true } });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const lastCall = onPermissionChanged.mock.calls[onPermissionChanged.mock.calls.length - 1][0];
-    expect(lastCall.permissions.Teams).toEqual(expect.arrayContaining(['team-1']));
-    expect(lastCall.permissions.Members).not.toContain('user-1');
-    expect(lastCall.permissions.Members).not.toContain('user-2');
-    expect(lastCall.permissions.Members).not.toContain('user-3');
-  });
+    it('should grant permission to the selected team and the board owner only when team is selected and saved', async () => {
+      const onPermissionChanged = jest.fn();
+      const props = makeProps({ onPermissionChanged });
+      const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
+      wrapper.find('input#permission-option-team-1').simulate('change', { target: { checked: true } });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const lastCall = onPermissionChanged.mock.calls[onPermissionChanged.mock.calls.length - 1][0];
+      expect(lastCall.permissions.Teams).toEqual(expect.arrayContaining(['team-1']));
+      expect(lastCall.permissions.Members).not.toContain('user-1');
+      expect(lastCall.permissions.Members).not.toContain('user-2');
+      expect(lastCall.permissions.Members).not.toContain('user-3');
+    });
 
-  it('should grant permission to the selected users only when their checkboxes are selected and saved', async () => {
-    const onPermissionChanged = jest.fn();
-    const props = makeProps({ onPermissionChanged });
-    const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
-    wrapper.find('input#permission-option-user-2').simulate('change', { target: { checked: true } });
-    wrapper.find('input#permission-option-user-3').simulate('change', { target: { checked: true } });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const lastCall = onPermissionChanged.mock.calls[onPermissionChanged.mock.calls.length - 1][0];
-    expect(lastCall.permissions.Members).toEqual(expect.arrayContaining(['user-2', 'user-3']));
-    expect(lastCall.permissions.Members).not.toContain('user-1');
-    expect(lastCall.permissions.Teams).not.toContain('team-1');
+    it('should grant permission to the selected users only when their checkboxes are selected and saved', async () => {
+      const onPermissionChanged = jest.fn();
+      const props = makeProps({ onPermissionChanged });
+      const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
+      wrapper.find('input#permission-option-user-2').simulate('change', { target: { checked: true } });
+      wrapper.find('input#permission-option-user-3').simulate('change', { target: { checked: true } });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const lastCall = onPermissionChanged.mock.calls[onPermissionChanged.mock.calls.length - 1][0];
+      expect(lastCall.permissions.Members).toEqual(expect.arrayContaining(['user-2', 'user-3']));
+      expect(lastCall.permissions.Members).not.toContain('user-1');
+      expect(lastCall.permissions.Teams).not.toContain('team-1');
+    });
+
+    it('should revoke all visible permissions when select all is unchecked and saved', async () => {
+      const onPermissionChanged = jest.fn();
+      // Start with all permissions selected (simulate initial state)
+      const props = makeProps({
+        onPermissionChanged,
+        currentUserId: 'user-1',
+        isNewBoardCreation: true,
+        board: {
+          ...mockedProps.board,
+          createdBy: { ...mockedProps.board.createdBy, id: 'user-3' }
+        },
+        // Optional: preset permissions as all selected to simulate unchecking
+        permissions: {
+          Teams: ['team-1'],
+          Members: ['user-1', 'user-2', 'user-3']
+        }
+      });
+
+      const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
+
+      // Simulate unchecking the select all checkbox
+      wrapper.find('input#select-all-permission-options-visible').simulate('change', { target: { checked: false } });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const lastCall = onPermissionChanged.mock.calls[onPermissionChanged.mock.calls.length - 1][0];
+
+      // Expect no Teams or Members to have permissions after unchecking "select all"
+      expect(lastCall.permissions.Teams).toHaveLength(0);
+      expect(lastCall.permissions.Members).toHaveLength(0);
+    });
   });
 
   describe('Board Owner Row Rendering', () => {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -773,17 +773,7 @@ describe('Search and Filtering', () => {
         Teams: [teamOption.id],
         Members: [adminOption.id, memberOption.id]
       },
-      permissionOptions: [
-        {
-          id: 'owner-id',
-          name: 'Board Owner',
-          uniqueName: 'owner-unique',
-          type: 'member'
-        },
-        teamOption,
-        adminOption,
-        memberOption
-      ]
+      permissionOptions: allOptions,
     });
 
     const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -795,3 +795,61 @@ describe('Select Permissions', () => {
     });
   });
 });
+
+describe('Test handleSearchTermChanged', () => {
+  let defaultProps: IFeedbackBoardMetadataFormPermissionsProps;
+
+  beforeEach(() => {
+    defaultProps = {
+      ...mockedProps,
+      board: {
+        ...mockedProps.board,
+        createdBy: { ...mockIdentityRef, id: 'owner-id', uniqueName: 'owner-id', displayName: 'Owner User' }
+      },
+      permissions: { Teams: [], Members: [] },
+      permissionOptions: [
+        { id: 'team-1', name: 'Alpha Team', uniqueName: 'alpha', type: 'team' },
+        { id: 'member-1', name: 'Bob Smith', uniqueName: 'robert.smith.05', type: 'member' },
+        { id: 'member-2', name: 'Charlie Brown', uniqueName: 'charles.brown.02', type: 'member' },
+      ] as FeedbackBoardPermissionOption[],
+      currentUserId: 'owner-id',
+      isNewBoardCreation: false,
+      onPermissionChanged: jest.fn(),
+    };
+  });
+
+  it('filters permission options based on search term', () => {
+    const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...defaultProps} />);
+
+    const input = wrapper.find('input#retrospective-permission-search-input');
+    expect(input).toHaveLength(1); // make sure input is found
+
+    // Simulate user typing 'Bob' into the search input
+    input.simulate('change', { target: { value: 'Bob' } });
+
+    wrapper.update(); // re-render after state changes
+
+    // Now find table rows filtered by search
+    const filtered = wrapper.find('tbody tr');
+    expect(filtered).toHaveLength(1);
+    expect(filtered.at(0).text()).toContain('Bob Smith');
+  });
+
+  it('shows all options when search term is cleared', () => {
+    const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...defaultProps} />);
+
+    const input = wrapper.find('input#retrospective-permission-search-input');
+    expect(input).toHaveLength(1);
+
+    // Type 'Bob' first
+    input.simulate('change', { target: { value: 'Bob' } });
+    wrapper.update();
+    expect(wrapper.find('tbody tr')).toHaveLength(1);
+
+    // Clear the search input
+    input.simulate('change', { target: { value: '' } });
+    wrapper.update();
+
+    expect(wrapper.find('tbody tr')).toHaveLength(defaultProps.permissionOptions.length);
+  });
+});

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -761,37 +761,36 @@ describe('Select Permissions', () => {
     expect(lastCall.permissions.Teams).not.toContain('team-1');
   });
 
-  describe('Search and Filtering', () => {
-    it('filters permission options correctly based on search term', () => {
-      const props = makeProps({
-        permissionOptions: [
-          { id: 'team-1', name: 'Team Alpha', uniqueName: 'team-alpha', type: 'team' },
-          { id: 'user-1', name: 'User Beta', uniqueName: 'user-beta', type: 'member' },
-          { id: 'group-1', name: '[Project]\\Group One', uniqueName: 'group-one', type: 'member' }, // group option, filtered out
-        ],
-      });
-
-      const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
-      const searchInput = wrapper.find('input#retrospective-permission-search-input');
-
-      // Type 'alpha' to filter
-      searchInput.simulate('change', { target: { value: 'alpha' } });
-      wrapper.update();
-
-      let rows = wrapper.find('tbody tr.option-row');
-      expect(rows.length).toBe(1);
-      expect(rows.text()).toContain('Team Alpha');
-
-      // Clear search to reset filter
-      searchInput.simulate('change', { target: { value: '' } });
-      wrapper.update();
-
-      rows = wrapper.find('tbody tr.option-row');
-      expect(rows.length).toBe(2); // Group is filtered out, so only 2 options remain
-      expect(rows.at(0).text()).toContain('Team Alpha');
-      expect(rows.at(1).text()).toContain('User Beta');
+describe('Search and Filtering', () => {
+  it('filters permission options correctly based on search term', () => {
+    const props = makeProps({
+      permissionOptions: [
+        { id: 'team-1', name: 'Team Alpha', uniqueName: 'team-alpha', type: 'team' },
+        { id: 'user-1', name: 'User Beta', uniqueName: 'user-beta', type: 'member' },
+        { id: 'group-1', name: '[Project]\\Group One', uniqueName: 'group-one', type: 'member' }, // group, should be filtered
+      ],
     });
+
+    const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
+
+    // Trigger the Fabric TextField's onChange manually
+    wrapper.find(TextField).prop('onChange')!(undefined as any, 'alpha');
+    wrapper.update();
+
+    let rows = wrapper.find('tbody tr.option-row');
+    expect(rows.length).toBe(1);
+    expect(rows.at(0).text()).toContain('Team Alpha');
+
+    // Clear search input
+    wrapper.find(TextField).prop('onChange')!(undefined as any, '');
+    wrapper.update();
+
+    rows = wrapper.find('tbody tr.option-row');
+    expect(rows.length).toBe(2); // Group is still filtered out
+    expect(rows.at(0).text()).toContain('Team Alpha');
+    expect(rows.at(1).text()).toContain('User Beta');
   });
+});
 
   describe('Board Owner Row Rendering', () => {
     it('should show the current user as board owner when creating a new board or copying a board (isNewBoardCreation: true)', () => {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -230,6 +230,12 @@ describe('Board Metadata Form Permissions', () => {
 
   describe('Permission Table', () => {
 
+    it('renders nothing when no permission options are provided', () => {
+  const props = makeProps({ permissionOptions: [] });
+  const wrapper = shallow(<FeedbackBoardMetadataFormPermissions {...props} />);
+  expect(wrapper.isEmptyRender()).toBe(true);
+});
+
     it('should show team permissions', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {
         ...mockedProps,

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -762,49 +762,62 @@ describe('Select Permissions', () => {
   });
 
 describe('Search and Filtering', () => {
-  it('filters permission options correctly based on search term', () => {
-    const props = makeProps({
-      currentUserId: 'user-1', // board owner
-      board: {
-        ...mockedProps.board,
-        createdBy: { ...mockedProps.board.createdBy, id: 'user-1' }
+it('filters permission options correctly based on search term', () => {
+  const props = makeProps({
+    board: {
+      ...mockedProps.board,
+      createdBy: { ...mockedProps.board.createdBy, id: 'owner-id' },
+    },
+    currentUserId: 'owner-id',
+    permissionOptions: [
+      {
+        id: 'owner-id',
+        name: 'Board Owner',
+        uniqueName: 'owner-unique',
+        type: 'member'
       },
-      permissions: {
-        Teams: [teamOption.id],
-        Members: [adminOption.id, memberOption.id]
+      {
+        id: 'team-1',
+        name: 'Team 1',
+        uniqueName: 'team1',
+        type: 'team'
       },
-      permissionOptions: allOptions,
-    });
-
-    const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
-
-    // Initially, all 4 options should be visible (owner, team, admin, member)
-    let rows = wrapper.find('tr.option-row');
-    expect(rows).toHaveLength(4);
-
-    // Board owner is always first
-    expect(rows.at(0).text()).toContain('Board Owner');
-    expect(rows.at(1).text()).toContain('Team 1');
-    expect(rows.at(2).text()).toContain('Team Admin');
-    expect(rows.at(3).text()).toContain('Team Member');
-
-    // Simulate entering 'Team' in the search input to filter options
-    wrapper.find('input#search-permissions').simulate('change', { target: { value: 'Team' } });
-
-    rows = wrapper.find('tr.option-row');
-    // Should filter to team and team members only, board owner excluded since it does not match 'Team'
-    expect(rows).toHaveLength(3);
-    expect(rows.at(0).text()).toContain('Team 1');
-    expect(rows.at(1).text()).toContain('Team Admin');
-    expect(rows.at(2).text()).toContain('Team Member');
-
-    // Simulate entering 'Owner' in the search input
-    wrapper.find('input#search-permissions').simulate('change', { target: { value: 'Owner' } });
-
-    rows = wrapper.find('tr.option-row');
-    expect(rows).toHaveLength(1);
-    expect(rows.at(0).text()).toContain('Board Owner');
+      {
+        id: 'admin-id',
+        name: 'Team Admin',
+        uniqueName: 'admin',
+        type: 'member'
+      },
+      {
+        id: 'member-id',
+        name: 'Team Member',
+        uniqueName: 'member',
+        type: 'member'
+      }
+    ],
+    permissions: {
+      Members: ['owner-id', 'admin-id', 'member-id'],
+      Teams: ['team-1']
+    }
   });
+
+  const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
+  wrapper.update();
+
+  const searchInput = wrapper.find('input').filterWhere(n => n.prop('id') === 'search-permissions');
+  expect(searchInput.exists()).toBe(true);
+
+  // Simulate searching for 'Team'
+  searchInput.simulate('change', { target: { value: 'Team' } });
+
+  wrapper.update();
+  const rows = wrapper.find('tr.option-row');
+
+  // Expect only Team-related rows to be shown
+  expect(rows.at(0).text()).toContain('Team 1');
+  expect(rows.at(1).text()).toContain('Team Admin');
+  expect(rows.at(2).text()).toContain('Team Member');
+});
 });
 
   describe('Board Owner Row Rendering', () => {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -103,6 +103,59 @@ describe('Board Metadata Form Permissions', () => {
     expect(textField.prop('value')).toEqual('');
   });
 
+  it('filters out group options based on pattern matching in name', () => {
+    const groupOptionAsMember: FeedbackBoardPermissionOption = {
+      id: 'group-member',
+      name: '[ProjectX]\\Developers',
+      uniqueName: 'projectx-devs',
+      type: 'member', // groups might appear as member
+      thumbnailUrl: '',
+    };
+
+    const groupOptionAsTeam: FeedbackBoardPermissionOption = {
+      id: 'group-team',
+      name: '[ProjectY]\\QA Team',
+      uniqueName: 'projecty-qa',
+      type: 'team', // groups might appear as team
+      thumbnailUrl: '',
+    };
+
+    const normalTeam: FeedbackBoardPermissionOption = {
+      id: 'team-normal',
+      name: 'Engineering Team',
+      uniqueName: 'eng-team',
+      type: 'team',
+      thumbnailUrl: '',
+    };
+
+    const normalMember: FeedbackBoardPermissionOption = {
+      id: 'member-normal',
+      name: 'Alice Johnson',
+      uniqueName: 'alice.j',
+      type: 'member',
+      thumbnailUrl: '',
+    };
+
+    const props = makeProps({
+      permissionOptions: [
+        normalTeam,
+        normalMember,
+        groupOptionAsMember,
+        groupOptionAsTeam,
+      ],
+    });
+
+    const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
+
+    // Group options should NOT render
+    expect(wrapper.text()).not.toContain('[ProjectX]\\Developers');
+    expect(wrapper.text()).not.toContain('[ProjectY]\\QA Team');
+
+    // Normal options SHOULD render
+    expect(wrapper.text()).toContain('Engineering Team');
+    expect(wrapper.text()).toContain('Alice Johnson');
+  });
+
   describe('Public Banner', () => {
     const publicBannerText: string = 'This board is visible to every member in the project.';
 
@@ -229,12 +282,6 @@ describe('Board Metadata Form Permissions', () => {
   });
 
   describe('Permission Table', () => {
-
-    it('renders nothing when no permission options are provided', () => {
-  const props = makeProps({ permissionOptions: [] });
-  const wrapper = shallow(<FeedbackBoardMetadataFormPermissions {...props} />);
-  expect(wrapper.isEmptyRender()).toBe(true);
-});
 
     it('should show team permissions', () => {
       const props: IFeedbackBoardMetadataFormPermissionsProps = {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow, ReactWrapper } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { TextField } from 'office-ui-fabric-react';
 import { mockUuid } from '../__mocks__/uuid/v4';
 import { testExistingBoard, testTeamId, testUserId } from '../__mocks__/mocked_components/mockedBoardMetadataForm';
@@ -760,65 +760,6 @@ describe('Select Permissions', () => {
     expect(lastCall.permissions.Members).not.toContain('user-1');
     expect(lastCall.permissions.Teams).not.toContain('team-1');
   });
-
-describe('Search and Filtering', () => {
-it('filters permission options correctly based on search term', () => {
-  const props = makeProps({
-    board: {
-      ...mockedProps.board,
-      createdBy: { ...mockedProps.board.createdBy, id: 'owner-id' },
-    },
-    currentUserId: 'owner-id',
-    permissionOptions: [
-      {
-        id: 'owner-id',
-        name: 'Board Owner',
-        uniqueName: 'owner-unique',
-        type: 'member'
-      },
-      {
-        id: 'team-1',
-        name: 'Team 1',
-        uniqueName: 'team1',
-        type: 'team'
-      },
-      {
-        id: 'admin-id',
-        name: 'Team Admin',
-        uniqueName: 'admin',
-        type: 'member'
-      },
-      {
-        id: 'member-id',
-        name: 'Team Member',
-        uniqueName: 'member',
-        type: 'member'
-      }
-    ],
-    permissions: {
-      Members: ['owner-id', 'admin-id', 'member-id'],
-      Teams: ['team-1']
-    }
-  });
-
-  const wrapper = mount(<FeedbackBoardMetadataFormPermissions {...props} />);
-  wrapper.update();
-
-  const searchInput = wrapper.find('input').filterWhere(n => n.prop('id') === 'search-permissions');
-  expect(searchInput.exists()).toBe(true);
-
-  // Simulate searching for 'Team'
-  searchInput.simulate('change', { target: { value: 'Team' } });
-
-  wrapper.update();
-  const rows = wrapper.find('tr.option-row');
-
-  // Expect only Team-related rows to be shown
-  expect(rows.at(0).text()).toContain('Team 1');
-  expect(rows.at(1).text()).toContain('Team Admin');
-  expect(rows.at(2).text()).toContain('Team Member');
-});
-});
 
   describe('Board Owner Row Rendering', () => {
     it('should show the current user as board owner when creating a new board or copying a board (isNewBoardCreation: true)', () => {

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -31,7 +31,6 @@ export interface FeedbackBoardPermissionOption {
 function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMetadataFormPermissionsProps>): JSX.Element {
   const [teamPermissions, setTeamPermissions] = React.useState(props.permissions?.Teams ?? []);
   const [memberPermissions, setMemberPermissions] = React.useState(props.permissions?.Members ?? []);
-  //const [filteredPermissionOptions, setFilteredPermissionOptions] = React.useState<FeedbackBoardPermissionOption[]>(props.permissionOptions);
   const [selectAllChecked, setSelectAllChecked] = React.useState<boolean>(false);
   const [searchTerm, setSearchTerm] = React.useState<string>('');
 
@@ -81,21 +80,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
       setMemberPermissions([...permissionList]);
     }
   }
-/*
-  const handleSearchTermChanged = (newSearchTerm: string) => {
-    setSearchTerm(newSearchTerm);
 
-    const filteredOptions = props.permissionOptions
-      .filter(option => !isGroupOption(option)) // Exclude groups
-      .filter(option => {
-        if (newSearchTerm.length === 0) return true;
-        return option.name.toLowerCase().includes(newSearchTerm.toLowerCase());
-      });
-
-    setSelectAllState();
-    setFilteredPermissionOptions(orderedPermissionOptions(filteredOptions));
-  };
-*/
   const handleSearchTermChanged = (newSearchTerm: string) => {
     setSearchTerm(newSearchTerm);
 
@@ -107,22 +92,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     setSelectAllState();
     setFilteredPermissionOptions(orderedPermissionOptions(filteredOptions));
   };
-/*
-  const handleSearchTermChanged = (newSearchTerm: string) => {
-    setSearchTerm(newSearchTerm);
 
-    const filteredOptions: FeedbackBoardPermissionOption[] = props.permissionOptions.filter(o => {
-      if(newSearchTerm.length === 0) {
-        return true
-      }
-
-      return o.name.toLowerCase().includes(newSearchTerm.toLowerCase());
-    });
-
-    setSelectAllState();
-    setFilteredPermissionOptions(orderedPermissionOptions(filteredOptions));
-  }
-*/
   const setSelectAllState = () => {
     const allVisibleIds = filteredPermissionOptions.map(o => o.id);
     const allPermissionIds = [...teamPermissions, ...memberPermissions];
@@ -257,8 +227,8 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
                       boxSide="start"
                       disabled={isBoardOwner}
                       checked={isBoardOwner || teamPermissions.includes(option.id) || memberPermissions.includes(option.id)}
-    indeterminate={teamPermissions.length === 0 && memberPermissions.length === 0 && isBoardOwner} // Set indeterminate only if no permissions exist
-                    onChange={(_, isChecked) => handlePermissionClicked(option, isChecked)}
+                      indeterminate={teamPermissions.length === 0 && memberPermissions.length === 0 && isBoardOwner} // Set indeterminate only if no permissions exist
+                      onChange={(_, isChecked) => handlePermissionClicked(option, isChecked)}
                     />
                   </td>
                   <td className="cell-content flex flex-row flex-nowrap">

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -41,7 +41,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
   );
   const canEditPermissions = isBoardOwner || isTeamAdmin;
   const isGroupOption = (option: FeedbackBoardPermissionOption): boolean => {
-    return /^\[[^\]]+\]\\/.test(option.uniqueName); // assumes groups have names like [project]\group
+    return /^\[[^\]]+\]\\/.test(option.name); // assumes groups have names like [project]\group
   };
 
   const cleanPermissionOptions = props.permissionOptions.filter(option => !isGroupOption(option)); // removes groups

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -31,7 +31,7 @@ export interface FeedbackBoardPermissionOption {
 function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMetadataFormPermissionsProps>): JSX.Element {
   const [teamPermissions, setTeamPermissions] = React.useState(props.permissions?.Teams ?? []);
   const [memberPermissions, setMemberPermissions] = React.useState(props.permissions?.Members ?? []);
-  const [filteredPermissionOptions, setFilteredPermissionOptions] = React.useState<FeedbackBoardPermissionOption[]>(props.permissionOptions);
+  //const [filteredPermissionOptions, setFilteredPermissionOptions] = React.useState<FeedbackBoardPermissionOption[]>(props.permissionOptions);
   const [selectAllChecked, setSelectAllChecked] = React.useState<boolean>(false);
   const [searchTerm, setSearchTerm] = React.useState<string>('');
 
@@ -40,6 +40,12 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     (option) => option.id === props.currentUserId && option.isTeamAdmin
   );
   const canEditPermissions = isBoardOwner || isTeamAdmin;
+  const isGroupOption = (option: FeedbackBoardPermissionOption): boolean => {
+    return /^\[[^\]]+\]\\/.test(option.uniqueName); // assumes groups have names like [project]\group
+  };
+
+  const cleanPermissionOptions = props.permissionOptions.filter(option => !isGroupOption(option)); // removes groups
+  const [filteredPermissionOptions, setFilteredPermissionOptions] = React.useState<FeedbackBoardPermissionOption[]>(cleanPermissionOptions);
 
   const handleSelectAllClicked = (checked: boolean) => {
     if (!canEditPermissions) return; // Block unauthorized users from selecting/unselecting all
@@ -75,7 +81,33 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
       setMemberPermissions([...permissionList]);
     }
   }
+/*
+  const handleSearchTermChanged = (newSearchTerm: string) => {
+    setSearchTerm(newSearchTerm);
 
+    const filteredOptions = props.permissionOptions
+      .filter(option => !isGroupOption(option)) // Exclude groups
+      .filter(option => {
+        if (newSearchTerm.length === 0) return true;
+        return option.name.toLowerCase().includes(newSearchTerm.toLowerCase());
+      });
+
+    setSelectAllState();
+    setFilteredPermissionOptions(orderedPermissionOptions(filteredOptions));
+  };
+*/
+  const handleSearchTermChanged = (newSearchTerm: string) => {
+    setSearchTerm(newSearchTerm);
+
+    const filteredOptions = cleanPermissionOptions.filter(option => {
+      if (newSearchTerm.length === 0) return true;
+      return option.name.toLowerCase().includes(newSearchTerm.toLowerCase());
+    });
+
+    setSelectAllState();
+    setFilteredPermissionOptions(orderedPermissionOptions(filteredOptions));
+  };
+/*
   const handleSearchTermChanged = (newSearchTerm: string) => {
     setSearchTerm(newSearchTerm);
 
@@ -90,7 +122,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     setSelectAllState();
     setFilteredPermissionOptions(orderedPermissionOptions(filteredOptions));
   }
-
+*/
   const setSelectAllState = () => {
     const allVisibleIds = filteredPermissionOptions.map(o => o.id);
     const allPermissionIds = [...teamPermissions, ...memberPermissions];


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #1295

## Description

Identify groups by pattern and remove them from permissions, since they were not functional.

## Bug or Feature?

- [x] Bug fix
- [ ] New feature
