### PR TITLE
blur feedback visually and hide feedback from screen reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ You can find the changelog of the Retrospective Extension below.
 
 ## v1.92.57
 
-* Improved hidden feedback behavior so screen displays blurred feedback and screen reader says "feedback blurred". From [GitHub PR #1796](https://github.com/microsoft/vsts-extension-retrospectives/pull/1796)
+* Improved hidden feedback behavior so screen displays blurred feedback and screen reader announces "feedback blurred". From [GitHub PR #1796](https://github.com/microsoft/vsts-extension-retrospectives/pull/1796)
 
 ## v1.92.56
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 You can find the changelog of the Retrospective Extension below.
 
-## v1.92.56
+## v1.92.57
 
-* Updated changelog and what's new to reflect current version updates and untangled changelog for prior two versions. From [GitHub PR #1783](https://github.com/microsoft/vsts-extension-retrospectives/pull/1783)
-* Introduced user setting with an option to toggle between scrolling by board or by column. From [GitHub PR #1780](https://github.com/microsoft/vsts-extension-retrospectives/pull/1780)
+* Improved hidden feedback behavior so screen displays blurred feedback and screen reader says "feedback blurred". From [GitHub PR #1796](https://github.com/microsoft/vsts-extension-retrospectives/pull/1796)
+
+## v1.92.56
 
 * Introduced Admin Settings with an option to configure available work item types for "Add work item".
 * Set available work item types to default to Requirement Backlog types for both the Act tab and Focus mode.
@@ -16,6 +17,9 @@ You can find the changelog of the Retrospective Extension below.
 
 From [GitHub PR #1777](https://github.com/microsoft/vsts-extension-retrospectives/pull/1777)
 
+* Updated changelog and what's new to reflect current version updates and untangled changelog for prior two versions. From [GitHub PR #1783](https://github.com/microsoft/vsts-extension-retrospectives/pull/1783)
+* Introduced user setting with an option to toggle between scrolling by board or by column. From [GitHub PR #1780](https://github.com/microsoft/vsts-extension-retrospectives/pull/1780)
+
 ## v1.92.55
 
 * Added function to search feedback across all boards for the current team. From [GitHub PR #1774](https://github.com/microsoft/vsts-extension-retrospectives/pull/1774)
@@ -24,8 +28,6 @@ From [GitHub PR #1777](https://github.com/microsoft/vsts-extension-retrospective
 * Isolated What's New for simpler maintenance and updated Changelog history. From [GitHub PR #1753](https://github.com/microsoft/vsts-extension-retrospectives/pull/1753)
 
 ## v1.92.54
-
-* Enhanced validation and error handling for retrospective title input. From [GitHub PR #1740](https://github.com/microsoft/vsts-extension-retrospectives/pull/1740)
 
 * Ensured editing a retrospective updates the intended board name and prevents accidental renames.
 * Prevented duplicate-name side effects that can impact board retrieval when updating board metadata.
@@ -38,8 +40,9 @@ From [GitHub PR #1777](https://github.com/microsoft/vsts-extension-retrospective
 * Reverted dialog backdrop styling from blurred background to shaded background for better context visibility and consistency with ADO.
 * Addressed remaining test code coverage gaps so now at 100%.
 
-From [GitHub PR #1728](https://github.com/microsoft/vsts-extension-retrospectives/pull/1728) and From [GitHub PR #1723](https://github.com/microsoft/vsts-extension-retrospectives/pull/1723)
+From [GitHub PR #1728](https://github.com/microsoft/vsts-extension-retrospectives/pull/1728) and [GitHub PR #1723](https://github.com/microsoft/vsts-extension-retrospectives/pull/1723)
 
+* Enhanced validation and error handling for retrospective title input. From [GitHub PR #1740](https://github.com/microsoft/vsts-extension-retrospectives/pull/1740)
 * Improved live-sync scoping when switching teams or boards so updates followed the currently selected retrospective context. From [GitHub PR #1678](https://github.com/microsoft/vsts-extension-retrospectives/pull/1678)
 
 ## v1.92.53

--- a/src/frontend/components/__tests__/feedbackItem.test.tsx
+++ b/src/frontend/components/__tests__/feedbackItem.test.tsx
@@ -406,7 +406,7 @@ describe("Feedback Item", () => {
 
       // Should remain in non-editing state (no input/textarea editor visible).
       expect(container.querySelector(".editable-text-input-container")).toBeNull();
-      expect(container.textContent).toContain("[Hidden Feedback]");
+      expect(container.textContent).toContain("Top secret");
     });
   });
 
@@ -602,7 +602,7 @@ describe("Feedback Item", () => {
       expect(container.querySelector(".hideFeedbackItem")).toBeTruthy();
     });
 
-    test("replaces title with placeholder text when hideFeedbackItems is true", () => {
+    test("keeps visual title but hides content from screen readers when hideFeedbackItems is true", () => {
       const props: any = {
         id: "test-hidden-text",
         title: "Secret Feedback Content",
@@ -628,13 +628,16 @@ describe("Feedback Item", () => {
         timerId: "",
         isGroupedCarouselItem: false,
       };
-      const { container, queryByText } = render(<FeedbackItem {...props} />);
+      const { container, getByText } = render(<FeedbackItem {...props} />);
+      const card = container.querySelector(`[data-feedback-item-id="${props.id}"]`) as HTMLElement;
+      const cardContent = container.querySelector(".card-content") as HTMLElement;
 
-      // Should show placeholder text
-      expect(container.textContent).toContain("[Hidden Feedback]");
+      // Should render real title text for visual blur treatment.
+      expect(getByText("Secret Feedback Content")).toBeInTheDocument();
 
-      // Should NOT show the actual title
-      expect(queryByText("Secret Feedback Content")).not.toBeInTheDocument();
+      // Screen readers should hear hidden-feedback semantics, not content.
+      expect(card.getAttribute("aria-label")).toContain("Title: feedback hidden.");
+      expect(cardContent.getAttribute("aria-hidden")).toBe("true");
     });
 
     test("shows actual title when user is the owner", () => {
@@ -2858,7 +2861,7 @@ describe("Feedback Item", () => {
   });
 
   describe("Accessibility - Obscured feedback (Issue #1318)", () => {
-    test("adds aria-hidden='true' to obscured feedback items", () => {
+    test("adds aria-hidden='true' to obscured feedback content", () => {
       const props: any = {
         id: "test-obscured-aria",
         title: "Hidden Feedback",
@@ -2889,8 +2892,11 @@ describe("Feedback Item", () => {
 
       const { container } = render(<FeedbackItem {...props} />);
       const feedbackItemElement = container.querySelector('[data-feedback-item-id="test-obscured-aria"]');
+      const contentElement = feedbackItemElement?.querySelector(".card-content");
 
-      expect(feedbackItemElement).toHaveAttribute("aria-hidden", "true");
+      expect(feedbackItemElement).not.toHaveAttribute("aria-hidden");
+      expect(feedbackItemElement).toHaveAttribute("aria-label", expect.stringContaining("Title: feedback hidden."));
+      expect(contentElement).toHaveAttribute("aria-hidden", "true");
     });
 
     test("does not add aria-hidden when feedback is not obscured", () => {
@@ -3756,9 +3762,9 @@ describe("Feedback Item", () => {
 
       const ariaLabel = voteUpButton.getAttribute("aria-label");
 
-      // Should not contain the title or [Hidden Feedback]
+      // Should not contain the original hidden feedback title.
       expect(ariaLabel).not.toContain("Hidden feedback title");
-      expect(ariaLabel).not.toContain("[Hidden Feedback]");
+      expect(ariaLabel).not.toContain("Hidden feedback");
 
       // Should contain simplified text
       expect(ariaLabel).toContain("Vote up");
@@ -9057,8 +9063,8 @@ describe("FeedbackItem additional coverage (merged)", () => {
     if (groupStack) {
       expect(container.textContent).toContain("Grouped Feedback");
 
-      // Check for hidden feedback placeholder for child1 (different user)
-      expect(container.textContent).toContain("[Hidden Feedback]");
+      // Hidden child content should render original text for visual blur treatment.
+      expect(container.textContent).toContain("Child 1");
 
       // Check for original column info for child1
       expect(container.textContent).toContain("Original Column:");

--- a/src/frontend/components/__tests__/feedbackItem.test.tsx
+++ b/src/frontend/components/__tests__/feedbackItem.test.tsx
@@ -636,7 +636,7 @@ describe("Feedback Item", () => {
       expect(getByText("Secret Feedback Content")).toBeInTheDocument();
 
       // Screen readers should hear hidden-feedback semantics, not content.
-      expect(card.getAttribute("aria-label")).toContain("Title: feedback hidden.");
+      expect(card.getAttribute("aria-label")).toContain("Title: feedback blurred.");
       expect(cardContent.getAttribute("aria-hidden")).toBe("true");
     });
 
@@ -2895,7 +2895,7 @@ describe("Feedback Item", () => {
       const contentElement = feedbackItemElement?.querySelector(".card-content");
 
       expect(feedbackItemElement).not.toHaveAttribute("aria-hidden");
-      expect(feedbackItemElement).toHaveAttribute("aria-label", expect.stringContaining("Title: feedback hidden."));
+      expect(feedbackItemElement).toHaveAttribute("aria-label", expect.stringContaining("Title: feedback blurred."));
       expect(contentElement).toHaveAttribute("aria-hidden", "true");
     });
 

--- a/src/frontend/components/__tests__/feedbackItem.test.tsx
+++ b/src/frontend/components/__tests__/feedbackItem.test.tsx
@@ -321,7 +321,7 @@ describe("Feedback Item", () => {
       const feedbackItem: IFeedbackItemDocument = {
         id: "hidden-item",
         boardId: testBoardId,
-        title: "Top secret",
+        title: "Sample hidden feedback",
         columnId: testColumnUuidOne,
         originalColumnId: testColumnUuidOne,
         upvotes: 0,
@@ -406,7 +406,7 @@ describe("Feedback Item", () => {
 
       // Should remain in non-editing state (no input/textarea editor visible).
       expect(container.querySelector(".editable-text-input-container")).toBeNull();
-      expect(container.textContent).toContain("Top secret");
+      expect(container.textContent).toContain("Sample hidden feedback");
     });
   });
 

--- a/src/frontend/components/__tests__/groupedFeedbackList.test.tsx
+++ b/src/frontend/components/__tests__/groupedFeedbackList.test.tsx
@@ -129,7 +129,7 @@ describe("GroupedFeedbackList", () => {
   });
 
   describe("Hidden feedback items", () => {
-    it("should show [Hidden Feedback] when hideFeedbackItems is true and item belongs to different user", () => {
+    it("should keep visual text but announce hidden feedback when hideFeedbackItems is true and item belongs to different user", () => {
       const childItem = createFeedbackItem({
         id: "child-1",
         title: "Secret Feedback",
@@ -139,8 +139,9 @@ describe("GroupedFeedbackList", () => {
 
       render(<GroupedFeedbackList {...defaultProps} childrenIds={["child-1"]} columnItems={columnItems} hideFeedbackItems={true} />);
 
-      expect(screen.getByText("[Hidden Feedback]")).toBeInTheDocument();
-      expect(screen.queryByText("Secret Feedback")).not.toBeInTheDocument();
+      const titleElement = screen.getByTitle("Hidden feedback");
+      expect(screen.getByText("Secret Feedback")).toBeInTheDocument();
+      expect(titleElement).toHaveAttribute("aria-label", "Related feedback: Hidden feedback");
     });
 
     it("should show actual title when hideFeedbackItems is true but item belongs to current user", () => {
@@ -166,8 +167,10 @@ describe("GroupedFeedbackList", () => {
 
       render(<GroupedFeedbackList {...defaultProps} childrenIds={["child-1"]} columnItems={columnItems} hideFeedbackItems={true} />);
 
-      const titleElement = screen.getByTitle("[Hidden Feedback]");
-      expect(titleElement).toHaveAttribute("aria-hidden", "true");
+      const titleElement = screen.getByTitle("Hidden feedback");
+      const visualTitle = screen.getByText("Hidden Item");
+      expect(titleElement).not.toHaveAttribute("aria-hidden");
+      expect(visualTitle).toHaveAttribute("aria-hidden", "true");
     });
   });
 
@@ -308,7 +311,7 @@ describe("GroupedFeedbackList", () => {
       render(<GroupedFeedbackList {...defaultProps} childrenIds={["child-1"]} columnItems={columnItems} hideFeedbackItems={false} />);
 
       expect(screen.getByText("Visible Feedback")).toBeInTheDocument();
-      expect(screen.queryByText("[Hidden Feedback]")).not.toBeInTheDocument();
+      expect(screen.getByTitle("Visible Feedback")).toBeInTheDocument();
     });
 
     it("should not have aria-hidden when item is not hidden", () => {

--- a/src/frontend/components/feedbackItem.tsx
+++ b/src/frontend/components/feedbackItem.tsx
@@ -979,7 +979,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
   // A feedback card may only be edited or deleted by the user who created it or by the board owner.
   const canModifyFeedbackItem = props.isBoardOwner || props.userIdRef === getUserIdentity().id;
   const displayTitle = props.title;
-  const accessibleDisplayTitle = hideFeedbackItems ? "feedback hidden" : props.title;
+  const accessibleDisplayTitle = hideFeedbackItems ? "feedback blurred" : props.title;
   const visualTitle = props.title;
   const creationDateFormatter = useMemo(() => new Intl.DateTimeFormat("default", { year: "numeric", month: "long", day: "numeric" }), []);
   const creationDateLabel = useMemo(() => {

--- a/src/frontend/components/feedbackItem.tsx
+++ b/src/frontend/components/feedbackItem.tsx
@@ -964,10 +964,6 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
     totalVotes = groupedVotes;
   }
 
-  const isDraggable = workflowState.isGroupPhase && !state.isMarkedForDeletion;
-  const showVoteButton = workflowState.isVotePhase;
-  const showVotes = showVoteButton || workflowState.isActPhase;
-
   const groupItemsCount = (props.groupedItemProps?.groupedCount ?? 0) + 1;
   const currentColumnItems = props.columns[props.columnId]?.columnItems;
 
@@ -978,9 +974,6 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
   const hideFeedbackItems = props.workflowPhase === "Collect" && props.hideFeedbackItems && props.userIdRef !== getUserIdentity().id;
   // A feedback card may only be edited or deleted by the user who created it or by the board owner.
   const canModifyFeedbackItem = props.isBoardOwner || props.userIdRef === getUserIdentity().id;
-  const displayTitle = props.title;
-  const accessibleDisplayTitle = hideFeedbackItems ? "feedback blurred" : props.title;
-  const visualTitle = props.title;
   const creationDateFormatter = useMemo(() => new Intl.DateTimeFormat("default", { year: "numeric", month: "long", day: "numeric" }), []);
   const creationDateLabel = useMemo(() => {
     if (!props.createdDate) {
@@ -995,7 +988,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
       label = isMainItem ? `Feedback group main item ${itemPosition} of ${totalItemsInColumn}. Group has ${groupItemsCount} items. ` : `Grouped feedback item. `;
     }
 
-    label += `Title: ${accessibleDisplayTitle}. `;
+    label += `Title: ${hideFeedbackItems ? "feedback blurred" : props.title}. `;
     if (props.createdBy && !hideFeedbackItems) {
       label += `Created by ${props.createdBy}. `;
     }
@@ -1004,15 +997,15 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
       label += `Created on ${creationDateLabel}. `;
     }
 
-    if (showVotes) {
+    if (workflowState.isVotePhase || workflowState.isActPhase) {
       label += `${totalVotes} total votes.`;
-      if (showVoteButton) {
+      if (workflowState.isVotePhase) {
         label += ` You have ${votesByUser} votes on this item.`;
       }
     }
 
     return label;
-  }, [itemPosition, totalItemsInColumn, isNotGroupedItem, isMainItem, groupItemsCount, accessibleDisplayTitle, props.createdBy, hideFeedbackItems, creationDateLabel, showVotes, totalVotes, showVoteButton, votesByUser]);
+  }, [itemPosition, totalItemsInColumn, isNotGroupedItem, isMainItem, groupItemsCount, hideFeedbackItems, props.title, props.createdBy, creationDateLabel, workflowState.isVotePhase, workflowState.isActPhase, totalVotes, votesByUser]);
 
   const curTimerState = props.timerState;
 
@@ -1025,7 +1018,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
       role="article"
       aria-roledescription={isNotGroupedItem ? "feedback item" : isMainItem ? "feedback group" : "grouped feedback item"}
       className={cn(isNotGroupedItem && "feedbackItem", !isNotGroupedItem && "feedbackItemGroupItem", !isNotGroupedItem && !isMainItem && "feedbackItemGroupGroupedItem", props.showAddedAnimation && "newFeedbackItem", state.isMarkedForDeletion && "removeFeedbackItem", hideFeedbackItems && "hideFeedbackItem")}
-      draggable={isDraggable}
+      draggable={workflowState.isGroupPhase && !state.isMarkedForDeletion}
       onDragStart={dragFeedbackItemStart}
       onDragOver={isNotGroupedItem ? dragFeedbackItemOverFeedbackItem : undefined}
       onDragEnd={dragFeedbackItemEnd}
@@ -1049,12 +1042,12 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
       }}
     >
       <div className="document-card-wrapper">
-        <DocumentCard className={cn("feedback-card-surface", isMainItem && "mainItemCard", !isMainItem && "groupedItemCard")} draggable={isDraggable}>
+        <DocumentCard className={cn("feedback-card-surface", isMainItem && "mainItemCard", !isMainItem && "groupedItemCard")} draggable={workflowState.isGroupPhase && !state.isMarkedForDeletion}>
           <div className="card-integral-part" style={{ borderLeftColor: props.accentColor }}>
             <div className="card-header">
               {mainGroupedItemInFocusMode && renderGroupButton(groupItemsCount, true)}
               {mainGroupedItemNotInFocusMode && renderGroupButton(groupItemsCount, false)}
-              {showVotes && (
+              {(workflowState.isVotePhase || workflowState.isActPhase) && (
                 <>
                   <button
                     title="Vote"
@@ -1062,7 +1055,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
                     aria-label={`Vote up. Current vote count is ${props.upvotes}`}
                     tabIndex={-1}
                     data-card-control="true"
-                    disabled={!showVoteButton || state.showVotedAnimation}
+                    disabled={!workflowState.isVotePhase || state.showVotedAnimation}
                     className={cn("feedback-action-button", "feedback-add-vote", state.showVotedAnimation && "voteAnimation")}
                     onClick={e => {
                       e.preventDefault();
@@ -1083,7 +1076,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
                     aria-label={`Vote down. Current vote count is ${props.upvotes}`}
                     tabIndex={-1}
                     data-card-control="true"
-                    disabled={!showVoteButton || state.showVotedAnimation}
+                    disabled={!workflowState.isVotePhase || state.showVotedAnimation}
                     className={cn("feedback-action-button", "feedback-add-vote", state.showVotedAnimation && "voteAnimation")}
                     onClick={e => {
                       e.preventDefault();
@@ -1152,17 +1145,17 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
             </div>
             <div className="card-content" aria-hidden={hideFeedbackItems || undefined}>
               {workflowState.isActPhase && isMainItem && <FeedbackItemTimer feedbackItemId={props.id} timerSecs={props.timerSecs} timerState={curTimerState} onTimerToggle={timerSwitch} />}
-              <EditableDocumentCardTitle isDisabled={hideFeedbackItems} isReadOnly={!canModifyFeedbackItem} isMultiline={true} title={visualTitle} isChangeEventRequired={false} onSave={onDocumentCardTitleSave} />
+              <EditableDocumentCardTitle isDisabled={hideFeedbackItems} isReadOnly={!canModifyFeedbackItem} isMultiline={true} title={props.title} isChangeEventRequired={false} onSave={onDocumentCardTitleSave} />
               {props.isFocusModalHidden && !workflowState.isCollectPhase && props.columnId !== props.originalColumnId && <div className="original-column-info">Original Column: {props.columns[props.originalColumnId]?.columnProperties?.title ?? "n/a"}</div>}
             </div>
             {feedbackCreationInformationContent()}
             <div className="card-footer">
               <div className="card-id">#{itemPosition}</div>
-              {showVoteButton && <div>{isNotGroupedItem || !isMainItem || (isMainItem && props.groupedItemProps!.isGroupExpanded) ? <span className="feedback-yourvote-count">[My Votes: {votesByUser}]</span> : <span className="feedback-yourvote-count bold">[My Votes: {groupedVotesByUser}]</span>}</div>}
+              {workflowState.isVotePhase && <div>{isNotGroupedItem || !isMainItem || (isMainItem && props.groupedItemProps!.isGroupExpanded) ? <span className="feedback-yourvote-count">[My Votes: {votesByUser}]</span> : <span className="feedback-yourvote-count bold">[My Votes: {groupedVotesByUser}]</span>}</div>}
             </div>
           </div>
           {isGroupedCarouselItem && isMainItem && state.isShowingGroupedChildrenTitles && <GroupedFeedbackList childrenIds={childrenIds} columnItems={columnItems} columns={props.columns} currentColumnId={props.columnId} workflowPhase={props.workflowPhase} hideFeedbackItems={props.hideFeedbackItems} isFocusModalHidden={props.isFocusModalHidden} />}
-          <div className="action-items">{workflowState.isActPhase && <ActionItemDisplay feedbackItemId={props.id} feedbackItemTitle={displayTitle} team={props.team} boardId={props.boardId} boardTitle={props.boardTitle} defaultAreaPath={props.defaultActionItemAreaPath} defaultIteration={props.defaultActionItemIteration} actionItems={props.actionItems} onUpdateActionItem={onUpdateActionItem} nonHiddenWorkItemTypes={props.nonHiddenWorkItemTypes} allWorkItemTypes={props.allWorkItemTypes} allowAddNewActionItem={isMainItem} shouldFocusActionItems={props.isFocusModalHidden} />}</div>
+          <div className="action-items">{workflowState.isActPhase && <ActionItemDisplay feedbackItemId={props.id} feedbackItemTitle={props.title} team={props.team} boardId={props.boardId} boardTitle={props.boardTitle} defaultAreaPath={props.defaultActionItemAreaPath} defaultIteration={props.defaultActionItemIteration} actionItems={props.actionItems} onUpdateActionItem={onUpdateActionItem} nonHiddenWorkItemTypes={props.nonHiddenWorkItemTypes} allWorkItemTypes={props.allWorkItemTypes} allowAddNewActionItem={isMainItem} shouldFocusActionItems={props.isFocusModalHidden} />}</div>
         </DocumentCard>
       </div>
       <dialog ref={deleteFeedbackDialogRef} className="delete-feedback-item-dialog dialog-width-sm" aria-label="Delete Feedback" onClose={() => setStateMerge({ isDeleteItemConfirmationDialogHidden: true })}>
@@ -1173,7 +1166,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
           </button>
         </div>
         <div className="subText">
-          {`Are you sure you want to delete the feedback "${displayTitle}"?`}
+          {`Are you sure you want to delete the feedback "${props.title}"?`}
           {!isNotGroupedItem && isMainItem ? " Any feedback grouped underneath this one will be ungrouped." : ""}
         </div>
         <div className="inner">
@@ -1291,7 +1284,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
             {getIconElement("close")}
           </button>
         </div>
-        <div className="subText">{`Are you sure you want to remove the feedback "${displayTitle}" from its current group?`}</div>
+        <div className="subText">{`Are you sure you want to remove the feedback "${props.title}" from its current group?`}</div>
         <div className="inner">
           <button className="button" onClick={onConfirmRemoveFeedbackItemFromGroup}>
             {t("remove_feedback_from_group")}

--- a/src/frontend/components/feedbackItem.tsx
+++ b/src/frontend/components/feedbackItem.tsx
@@ -978,7 +978,9 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
   const hideFeedbackItems = props.workflowPhase === "Collect" && props.hideFeedbackItems && props.userIdRef !== getUserIdentity().id;
   // A feedback card may only be edited or deleted by the user who created it or by the board owner.
   const canModifyFeedbackItem = props.isBoardOwner || props.userIdRef === getUserIdentity().id;
-  const displayTitle = hideFeedbackItems ? "[Hidden Feedback]" : props.title;
+  const displayTitle = props.title;
+  const accessibleDisplayTitle = hideFeedbackItems ? "feedback hidden" : props.title;
+  const visualTitle = props.title;
   const creationDateFormatter = useMemo(() => new Intl.DateTimeFormat("default", { year: "numeric", month: "long", day: "numeric" }), []);
   const creationDateLabel = useMemo(() => {
     if (!props.createdDate) {
@@ -993,7 +995,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
       label = isMainItem ? `Feedback group main item ${itemPosition} of ${totalItemsInColumn}. Group has ${groupItemsCount} items. ` : `Grouped feedback item. `;
     }
 
-    label += `Title: ${displayTitle}. `;
+    label += `Title: ${accessibleDisplayTitle}. `;
     if (props.createdBy && !hideFeedbackItems) {
       label += `Created by ${props.createdBy}. `;
     }
@@ -1010,7 +1012,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
     }
 
     return label;
-  }, [itemPosition, totalItemsInColumn, isNotGroupedItem, isMainItem, groupItemsCount, displayTitle, props.createdBy, hideFeedbackItems, creationDateLabel, showVotes, totalVotes, showVoteButton, votesByUser]);
+  }, [itemPosition, totalItemsInColumn, isNotGroupedItem, isMainItem, groupItemsCount, accessibleDisplayTitle, props.createdBy, hideFeedbackItems, creationDateLabel, showVotes, totalVotes, showVoteButton, votesByUser]);
 
   const curTimerState = props.timerState;
 
@@ -1020,7 +1022,6 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
       data-feedback-item-id={props.id}
       tabIndex={0}
       aria-label={ariaLabel}
-      aria-hidden={hideFeedbackItems || undefined}
       role="article"
       aria-roledescription={isNotGroupedItem ? "feedback item" : isMainItem ? "feedback group" : "grouped feedback item"}
       className={cn(isNotGroupedItem && "feedbackItem", !isNotGroupedItem && "feedbackItemGroupItem", !isNotGroupedItem && !isMainItem && "feedbackItemGroupGroupedItem", props.showAddedAnimation && "newFeedbackItem", state.isMarkedForDeletion && "removeFeedbackItem", hideFeedbackItems && "hideFeedbackItem")}
@@ -1149,9 +1150,9 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
                 </div>
               )}
             </div>
-            <div className="card-content">
+            <div className="card-content" aria-hidden={hideFeedbackItems || undefined}>
               {workflowState.isActPhase && isMainItem && <FeedbackItemTimer feedbackItemId={props.id} timerSecs={props.timerSecs} timerState={curTimerState} onTimerToggle={timerSwitch} />}
-              <EditableDocumentCardTitle isDisabled={hideFeedbackItems} isReadOnly={!canModifyFeedbackItem} isMultiline={true} title={displayTitle} isChangeEventRequired={false} onSave={onDocumentCardTitleSave} />
+              <EditableDocumentCardTitle isDisabled={hideFeedbackItems} isReadOnly={!canModifyFeedbackItem} isMultiline={true} title={visualTitle} isChangeEventRequired={false} onSave={onDocumentCardTitleSave} />
               {props.isFocusModalHidden && !workflowState.isCollectPhase && props.columnId !== props.originalColumnId && <div className="original-column-info">Original Column: {props.columns[props.originalColumnId]?.columnProperties?.title ?? "n/a"}</div>}
             </div>
             {feedbackCreationInformationContent()}

--- a/src/frontend/components/groupedFeedbackList.tsx
+++ b/src/frontend/components/groupedFeedbackList.tsx
@@ -50,24 +50,16 @@ const GroupedFeedbackList: React.FC<IGroupedFeedbackListProps> = ({ childrenIds,
           const childCard: IColumnItem | undefined = columnItemsById.get(id);
           const originalColumn = childCard ? columns[childCard.feedbackItem.originalColumnId] : null;
           const childItemHidden = !!childCard && hideFeedbackItems && childCard.feedbackItem.userIdRef !== currentUserId;
-          const visualTitle = childCard?.feedbackItem.title;
-          const accessibleTitle = childItemHidden ? "Hidden feedback" : childCard?.feedbackItem.title;
-          const titleText = childItemHidden ? "Hidden feedback" : childCard?.feedbackItem.title;
 
           return (
             childCard && (
               <li key={id} role="listitem">
-                <div
-                  className="icon"
-                  style={{
-                    borderRightColor: originalColumn?.columnProperties?.accentColor,
-                  }}
-                >
+                <div className="icon" style={{ borderRightColor: originalColumn?.columnProperties?.accentColor }}>
                   {getIconElement("sms")}
                 </div>
-                <div className="related-feedback-title" aria-label={`Related feedback: ${accessibleTitle}`} title={titleText}>
+                <div className="related-feedback-title" aria-label={`Related feedback: ${childItemHidden ? "Hidden feedback" : childCard.feedbackItem.title}`} title={childItemHidden ? "Hidden feedback" : childCard.feedbackItem.title}>
                   <span className={childItemHidden ? "hidden-related-feedback-title" : undefined} aria-hidden={childItemHidden || undefined}>
-                    {visualTitle}
+                    {childCard.feedbackItem.title}
                   </span>
                 </div>
                 {isFocusModalHidden && currentColumnId !== originalColumn?.columnProperties?.id && originalColumn && <div className="original-column-info">Original Column: {originalColumn.columnProperties.title}</div>}

--- a/src/frontend/components/groupedFeedbackList.tsx
+++ b/src/frontend/components/groupedFeedbackList.tsx
@@ -50,7 +50,9 @@ const GroupedFeedbackList: React.FC<IGroupedFeedbackListProps> = ({ childrenIds,
           const childCard: IColumnItem | undefined = columnItemsById.get(id);
           const originalColumn = childCard ? columns[childCard.feedbackItem.originalColumnId] : null;
           const childItemHidden = !!childCard && hideFeedbackItems && childCard.feedbackItem.userIdRef !== currentUserId;
-          const childDisplayTitle = childItemHidden ? "[Hidden Feedback]" : childCard?.feedbackItem.title;
+          const visualTitle = childCard?.feedbackItem.title;
+          const accessibleTitle = childItemHidden ? "Hidden feedback" : childCard?.feedbackItem.title;
+          const titleText = childItemHidden ? "Hidden feedback" : childCard?.feedbackItem.title;
 
           return (
             childCard && (
@@ -63,8 +65,10 @@ const GroupedFeedbackList: React.FC<IGroupedFeedbackListProps> = ({ childrenIds,
                 >
                   {getIconElement("sms")}
                 </div>
-                <div className="related-feedback-title" aria-label={`Related feedback: ${childDisplayTitle}`} aria-hidden={childItemHidden || undefined} title={childDisplayTitle}>
-                  {childDisplayTitle}
+                <div className="related-feedback-title" aria-label={`Related feedback: ${accessibleTitle}`} title={titleText}>
+                  <span className={childItemHidden ? "hidden-related-feedback-title" : undefined} aria-hidden={childItemHidden || undefined}>
+                    {visualTitle}
+                  </span>
                 </div>
                 {isFocusModalHidden && currentColumnId !== originalColumn?.columnProperties?.id && originalColumn && <div className="original-column-info">Original Column: {originalColumn.columnProperties.title}</div>}
               </li>

--- a/src/frontend/components/whatsNewDialog.tsx
+++ b/src/frontend/components/whatsNewDialog.tsx
@@ -9,7 +9,7 @@ interface IWhatsNewDialogProps {
 const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.57 and v1.92.56 include:";
 
 const WHATS_NEW_ITEMS = [
-  "Improved hidden feedback behavior to display blurred feedback while reading \"feedback blurred\".",
+  "Improved hidden feedback behavior to display blurred feedback while announcing \"feedback blurred\".",
   "Added user settings to toggle between show all teams or my teams and to toggle between scrolling by board or by column.",
   "Added team admin setting for configuring available work item types in \"Add work item\".",
   "Defaulted add-work-item type options to Requirement Backlog types for the Act tab and Focus mode.",

--- a/src/frontend/components/whatsNewDialog.tsx
+++ b/src/frontend/components/whatsNewDialog.tsx
@@ -6,16 +6,14 @@ interface IWhatsNewDialogProps {
   dialogRef: React.RefObject<HTMLDialogElement | null>;
 }
 
-const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.56 and v1.92.55 include:";
+const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.57 and v1.92.56 include:";
 
 const WHATS_NEW_ITEMS = [
+  "Improved hidden feedback behavior to display blurred feedback while reading \"feedback blurred\".",
   "Added user settings to toggle between show all teams or my teams and to toggle between scrolling by board or by column.",
   "Added team admin setting for configuring available work item types in \"Add work item\".",
   "Defaulted add-work-item type options to Requirement Backlog types for the Act tab and Focus mode.",
   "Adjusted the \"Add work item\" selection to ensure the full list of work item types is visible for the Act tab and Focus mode, even with a long list of custom types.",
-  "Added function to search for feedback across all boards in the current team.",
-  "Restricted editing and deleting feedback cards to the card creator or board owner.",
-  "Resolved initial-load race conditions that could result in missing teams or boards.",
 ];
 
 const WHATS_NEW_FOOTER_TEXT = "Refer to the Changelog for a complete history of updates.";

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -2275,6 +2275,10 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
       & .related-feedback-title {
         @apply ml-2.5 text-(--text-primary-color) text-xs content-center [-webkit-box-orient:vertical] overflow-hidden text-ellipsis [-webkit-line-clamp:2];
         display: -webkit-box;
+
+        & .hidden-related-feedback-title {
+          @apply blur-xs pointer-events-none;
+        }
       }
     }
   }


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): Improve hidden feedback behavior for displayed text and screen reader

## Description

Treats hidden feedback differently for visual display and screen reader, by displaying blurred feedback and redirecting screen reader to read "feedback hidden".

## Bug or Feature?

- [ ] Bug fix
- [x] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated any relevant documentation accordingly.
- [x] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`, to be included with the next release.
  - [x] I have included a link to this PR in that blurb.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [x] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both landscape and portrait views, when needed.
- [x] I have tested my changes both zoomed in and zoomed out.
- [x] I have included image descriptions and aria-labels where I can.