### PR TITLE
isBoardOwner or isTeamAdmin canManageBoards

### DIFF
--- a/.github/workflows/ci_cd_frontend.yml
+++ b/.github/workflows/ci_cd_frontend.yml
@@ -115,6 +115,10 @@ jobs:
           echo "ReactTable" >> base.txt
           echo "README" >> base.txt
           echo "OpenSSF" >> base.txt
+          echo "Dependabot" >> base.txt
+          echo "lockfile" >> base.txt
+          echo "devDependency" >> base.txt
+          echo "roadmap" >> base.txt
           echo "CI_Backend" >> base.txt
           echo "Moq" >> base.txt
           echo "xUnit" >> base.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ You can find the changelog of the Retrospective Extension below.
 
 ## v1.92.57
 
+* Extended permissions so board owners and team admins can update column notes and edit or delete feedback cards. From [GitHub PR #1805](https://github.com/microsoft/vsts-extension-retrospectives/pull/1805)
 * Improved hidden feedback behavior so screen displays blurred feedback and screen reader announces "feedback blurred". From [GitHub PR #1796](https://github.com/microsoft/vsts-extension-retrospectives/pull/1796)
 
 ## v1.92.56

--- a/documentation/release-promotion.prompt.md
+++ b/documentation/release-promotion.prompt.md
@@ -20,7 +20,7 @@ Use these rules:
 - If production metadata uses a placeholder version and no newer tag is available, infer the target version as the next patch version after the latest `CHANGELOG.md` release heading.
 - Treat the previous production version as the release immediately before the target version in `CHANGELOG.md` or Git tags.
 - If the changelog is behind by multiple versions, document the full latest production range needed to bring release-facing content current.
-- If evidence conflicts, choose the latest semver-like production version reachable from the repo state, proceed, and call out the assumption in the final response.
+- If evidence conflicts, choose the latest production semantic version reachable from the repository state, proceed, and call out the assumption in the final response.
 - Only stop to ask a question if the repo has no usable version signal or no usable Git history to identify changes.
 
 ## Files To Update
@@ -32,7 +32,7 @@ Update these files as needed:
 - `README.md`, only if the release changes user-facing behavior, setup, screenshots, or core positioning
 - `src/frontend/assets/PACKAGE-DESCRIPTION.md`, only if the release changes marketplace-facing behavior, screenshots, or positioning
 
-Do not manually edit generated files such as coverage output or bundled distribution files unless this repo's release process explicitly requires it.
+Do not manually edit generated files such as coverage output or bundled distribution files unless this repository's release process explicitly requires it.
 
 ## What To Review
 
@@ -46,7 +46,7 @@ Before editing, inspect the changes between the inferred previous production ver
 
 Identify user-facing features, behavior changes, bug fixes, accessibility improvements, reliability improvements, and meaningful non-dependency maintenance changes. Exclude noisy internal churn unless it matters to users, operators, maintainers, security, performance, or reliability.
 
-Do not include dependency-only updates in release-facing content. Exclude Dependabot PRs, package manager updates, lockfile-only changes, and dependency or devDependency version changes in files such as `package.json`, `package-lock.json`, `.csproj`, or `packages.lock.json`. If a PR only updates dependencies or dependency metadata, ignore it for `CHANGELOG.md`, What's New, README, and package description updates.
+Do not include dependency-only updates in release-facing content. Exclude Dependabot PRs, package manager updates, lockfile changes only, and dependency or devDependency version changes in files such as `package.json`, `package-lock.json`, `.csproj`, or `packages.lock.json`. If a PR only updates dependencies or dependency metadata, ignore it for `CHANGELOG.md`, What's New, README, and package description updates.
 
 ## Changelog Requirements
 
@@ -59,7 +59,7 @@ Update `CHANGELOG.md` so it is accurate for the inferred target production versi
 - Include meaningful user-facing changes, fixes, accessibility updates, reliability improvements, and relevant non-dependency maintenance items.
 - Do not include dependency updates, Dependabot PRs, lockfile changes, or package manifest dependency/devDependency version bumps.
 - Keep entries concise but specific enough that users and maintainers understand what changed.
-- Preserve the repo's existing changelog style, including PR links where available.
+- Preserve the repository's existing changelog style, including PR links where available.
 - Use past tense consistently.
 - Do not use future tense or roadmap language such as "will add", "will fix", "will improve", "coming soon", or "planned".
 

--- a/src/backend.tests/packages.lock.json
+++ b/src/backend.tests/packages.lock.json
@@ -132,19 +132,19 @@
       },
       "Microsoft.Azure.SignalR": {
         "type": "Transitive",
-        "resolved": "1.33.0",
-        "contentHash": "MExV/CBiVGQG8M2sW59iXH//8Kc6+OZR1roIKM/q5zZcIaA2h5bcmrpUdCOBuFfV7zHtGpXCun5A0qVf/u+Jtw==",
+        "resolved": "1.33.1",
+        "contentHash": "WdHXYYxR8Ed7EAivuK143oSQMAp3dDlql6pf7p5xwW/l5hxAM5IF9KlHE+SeHz0B5dg2jUnRNCYCAplVEcBHdg==",
         "dependencies": {
           "Azure.Identity": "1.11.4",
-          "Microsoft.Azure.SignalR.Protocols": "1.33.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.33.1",
           "Microsoft.Extensions.Http": "2.1.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.Azure.SignalR.Protocols": {
         "type": "Transitive",
-        "resolved": "1.33.0",
-        "contentHash": "xb4iPY5zDEqIxI493Iz8O7NPhmL2THB4vIftPWSsHh78zCz39YSUw0IJX3LtglDDQK2Hb16HLlLRcpRJrFvt5A==",
+        "resolved": "1.33.1",
+        "contentHash": "LrYSu8y0aSrt1r50A40mcNPpOgHbHEKXkp069YvJcdOTj4E7X1ZKHOtBOfNAeu/O03qSkaOw+GACcf+JIhP/1A==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "2.1.1"
         }
@@ -542,7 +542,7 @@
           "Azure.Security.KeyVault.Secrets": "[4.11.0, )",
           "Microsoft.ApplicationInsights.AspNetCore": "[3.1.2, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.9, )",
-          "Microsoft.Azure.SignalR": "[1.33.0, )",
+          "Microsoft.Azure.SignalR": "[1.33.1, )",
           "System.IdentityModel.Tokens.Jwt": "[8.19.1, )"
         }
       }

--- a/src/frontend/components/__tests__/feedbackBoard.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoard.test.tsx
@@ -1800,6 +1800,29 @@ describe("FeedbackBoard Component", () => {
       const columnProps = feedbackColumnPropsSpy.mock.calls[feedbackColumnPropsSpy.mock.calls.length - 1]?.[0];
       expect(columnProps?.showColumnEditButton).toBe(false);
     });
+
+    it("shows column edit button when user is Team Admin but not board creator", async () => {
+      const creatorBoard = {
+        ...mockedBoard,
+        createdBy: { ...mockedIdentity, id: "different-user-id" },
+      };
+      const propsWithTeamAdmin = {
+        ...mockedProps,
+        board: creatorBoard,
+        userId: "current-user-id",
+        currentUserIsTeamAdmin: true,
+      };
+
+      render(<FeedbackBoard {...propsWithTeamAdmin} />);
+
+      await waitFor(() => {
+        expect(feedbackColumnPropsSpy).toHaveBeenCalled();
+      });
+
+      const columnProps = feedbackColumnPropsSpy.mock.calls[feedbackColumnPropsSpy.mock.calls.length - 1]?.[0];
+      expect(columnProps?.showColumnEditButton).toBe(true);
+      expect(columnProps?.canManageBoard).toBe(true);
+    });
   });
 
   describe("Column Item Finding", () => {
@@ -2293,7 +2316,7 @@ describe("FeedbackBoard Component", () => {
       expect(onVoteCasted).toHaveBeenCalled();
     });
 
-    it("sets isBoardOwner to true when the current user created the board", async () => {
+    it("sets canManageBoard to true when the current user created the board", async () => {
       const onFocusModeModelChange = jest.fn();
       // mockedProps.userId and mockedBoard.createdBy.id are both "", so the current user is the owner.
       const ownerProps = {
@@ -2310,10 +2333,10 @@ describe("FeedbackBoard Component", () => {
       });
 
       const focusModeModel = onFocusModeModelChange.mock.calls[onFocusModeModelChange.mock.calls.length - 1]?.[0];
-      expect(focusModeModel?.isBoardOwner).toBe(true);
+      expect(focusModeModel?.canManageBoard).toBe(true);
     });
 
-    it("sets isBoardOwner to false when the board has no creator", async () => {
+    it("sets canManageBoard to false when the board has no creator and user is not Team Admin", async () => {
       const onFocusModeModelChange = jest.fn();
       const boardWithoutCreator: IFeedbackBoardDocument = { ...mockedBoard, createdBy: undefined };
       const nonOwnerProps = {
@@ -2332,7 +2355,33 @@ describe("FeedbackBoard Component", () => {
       });
 
       const focusModeModel = onFocusModeModelChange.mock.calls[onFocusModeModelChange.mock.calls.length - 1]?.[0];
-      expect(focusModeModel?.isBoardOwner).toBe(false);
+      expect(focusModeModel?.canManageBoard).toBe(false);
+    });
+
+    it("sets canManageBoard true when the current user is Team Admin", async () => {
+      const onFocusModeModelChange = jest.fn();
+      const boardWithDifferentOwner: IFeedbackBoardDocument = {
+        ...mockedBoard,
+        createdBy: { ...mockedIdentity, id: "different-user-id" },
+      };
+      const teamAdminProps = {
+        ...mockedProps,
+        board: boardWithDifferentOwner,
+        userId: "current-user-id",
+        currentUserIsTeamAdmin: true,
+        onFocusModeModelChange,
+      };
+
+      (itemDataService.getFeedbackItemsForBoard as jest.Mock).mockResolvedValue([]);
+
+      render(<FeedbackBoard {...teamAdminProps} />);
+
+      await waitFor(() => {
+        expect(onFocusModeModelChange).toHaveBeenCalled();
+      });
+
+      const focusModeModel = onFocusModeModelChange.mock.calls[onFocusModeModelChange.mock.calls.length - 1]?.[0];
+      expect(focusModeModel?.canManageBoard).toBe(true);
     });
 
     it("uses focus mode work item types when they are provided", async () => {

--- a/src/frontend/components/__tests__/feedbackBoard.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoard.test.tsx
@@ -2336,13 +2336,17 @@ describe("FeedbackBoard Component", () => {
       expect(focusModeModel?.canManageBoard).toBe(true);
     });
 
-    it("sets canManageBoard to false when the board has no creator and user is not Team Admin", async () => {
+    it("sets canManageBoard to false when the current user is not the board creator and not Team Admin", async () => {
       const onFocusModeModelChange = jest.fn();
-      const boardWithoutCreator: IFeedbackBoardDocument = { ...mockedBoard, createdBy: undefined };
+      const boardWithDifferentOwner: IFeedbackBoardDocument = {
+        ...mockedBoard,
+        createdBy: { ...mockedIdentity, id: "board-owner-id" },
+      };
       const nonOwnerProps = {
         ...mockedProps,
-        board: boardWithoutCreator,
-        userId: "some-other-user",
+        board: boardWithDifferentOwner,
+        userId: "current-user-id",
+        currentUserIsTeamAdmin: false,
         onFocusModeModelChange,
       };
 

--- a/src/frontend/components/__tests__/feedbackColumn.test.tsx
+++ b/src/frontend/components/__tests__/feedbackColumn.test.tsx
@@ -135,6 +135,28 @@ describe("Feedback Column ", () => {
       expect(feedbackItemProps.accentColor).toEqual(expectedAccentColor);
     });
 
+    it("defaults canManageBoard to false when column props do not provide it", () => {
+      const columnPropsWithoutCanManageBoard = {
+        ...testColumnProps,
+        canManageBoard: undefined as boolean | undefined,
+      };
+
+      const feedbackItemProps = createFeedbackItemProps(columnPropsWithoutCanManageBoard, testColumnProps.columnItems[0]);
+
+      expect(feedbackItemProps.canManageBoard).toBe(false);
+    });
+
+    it("uses canManageBoard from column props when provided", () => {
+      const columnPropsWithCanManageBoard = {
+        ...testColumnProps,
+        canManageBoard: true,
+      };
+
+      const feedbackItemProps = createFeedbackItemProps(columnPropsWithCanManageBoard, testColumnProps.columnItems[0]);
+
+      expect(feedbackItemProps.canManageBoard).toBe(true);
+    });
+
     it("renders grouped items with FeedbackItemGroup", () => {
       const baseFeedbackItem = {
         id: "parent-item",

--- a/src/frontend/components/__tests__/feedbackItem.test.tsx
+++ b/src/frontend/components/__tests__/feedbackItem.test.tsx
@@ -8110,6 +8110,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
       shouldHaveFocus: false,
       hideFeedbackItems: false,
       userIdRef: doc.userIdRef,
+      canManageBoard: false,
       timerSecs: 0,
       timerState: false,
       timerId: null,
@@ -8154,7 +8155,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
 
     test("shows the delete option to the feedback creator", async () => {
       // The mocked current user id is "test-user-id".
-      const props = makeProps({ userIdRef: "test-user-id", isBoardOwner: false });
+      const props = makeProps({ userIdRef: "test-user-id", canManageBoard: false });
       render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 
@@ -8164,7 +8165,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
     });
 
     test("shows the delete option to the board owner for another user's feedback", async () => {
-      const props = makeProps({ userIdRef: "another-user", isBoardOwner: true });
+      const props = makeProps({ userIdRef: "another-user", canManageBoard: true });
       render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 
@@ -8174,7 +8175,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
     });
 
     test("shows the delete option to the board owner for their own feedback", async () => {
-      const props = makeProps({ userIdRef: "test-user-id", isBoardOwner: true });
+      const props = makeProps({ userIdRef: "test-user-id", canManageBoard: true });
       render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 
@@ -8184,7 +8185,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
     });
 
     test("hides the delete option from users who neither created the feedback nor own the board", async () => {
-      const props = makeProps({ userIdRef: "another-user", isBoardOwner: false });
+      const props = makeProps({ userIdRef: "another-user", canManageBoard: false });
       render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 
@@ -8196,7 +8197,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
     });
 
     test("does not open the delete dialog when a non-owner presses the Delete key", async () => {
-      const props = makeProps({ userIdRef: "another-user", isBoardOwner: false });
+      const props = makeProps({ userIdRef: "another-user", canManageBoard: false });
       const { container } = render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 
@@ -8214,7 +8215,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
 
   describe("Edit permission (creator or board owner only)", () => {
     test("lets the creator edit their own feedback title", async () => {
-      const props = makeProps({ userIdRef: "test-user-id", isBoardOwner: false });
+      const props = makeProps({ userIdRef: "test-user-id", canManageBoard: false });
       const { container } = render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 
@@ -8227,7 +8228,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
     });
 
     test("lets the board owner edit another user's feedback title", async () => {
-      const props = makeProps({ userIdRef: "another-user", isBoardOwner: true });
+      const props = makeProps({ userIdRef: "another-user", canManageBoard: true });
       const { container } = render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 
@@ -8240,7 +8241,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
     });
 
     test("lets the board owner edit their own feedback title", async () => {
-      const props = makeProps({ userIdRef: "test-user-id", isBoardOwner: true });
+      const props = makeProps({ userIdRef: "test-user-id", canManageBoard: true });
       const { container } = render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 
@@ -8253,7 +8254,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
     });
 
     test("marks another user's feedback title as read-only for non-owners", async () => {
-      const props = makeProps({ userIdRef: "another-user", isBoardOwner: false });
+      const props = makeProps({ userIdRef: "another-user", canManageBoard: false });
       const { container } = render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 
@@ -8269,7 +8270,7 @@ describe("FeedbackItem additional coverage (merged)", () => {
     });
 
     test("does not enter edit mode when a non-owner presses Enter on the card", async () => {
-      const props = makeProps({ userIdRef: "another-user", isBoardOwner: false });
+      const props = makeProps({ userIdRef: "another-user", canManageBoard: false });
       const { container } = render(<FeedbackItem {...props} />);
       await waitFor(() => expect(itemDataService.getFeedbackItem).toHaveBeenCalled());
 

--- a/src/frontend/components/feedbackBoard.tsx
+++ b/src/frontend/components/feedbackBoard.tsx
@@ -15,6 +15,7 @@ import type { FocusModeModel } from "./feedbackCarousel";
 import { useTrackMetric } from "@microsoft/applicationinsights-react-js";
 import { appInsights, reactPlugin } from "../utilities/telemetryClient";
 import { isAnyModalDialogOpen } from "../utilities/dialogHelper";
+import { getBoardAccess } from "../utilities/boardAccessHelper";
 import { getIconElement } from "./icons";
 
 export interface FeedbackBoardProps {
@@ -30,6 +31,7 @@ export interface FeedbackBoardProps {
   hideFeedbackItems: boolean;
   onFocusModeModelChange?: (model: FocusModeModel) => void;
   userId: string;
+  currentUserIsTeamAdmin?: boolean;
   onVoteCasted?: () => void;
   onColumnNotesChange?: (columnId: string, notes: string) => Promise<void>;
   scrollMode?: "column" | "board";
@@ -102,7 +104,7 @@ const getColumnsWithReleasedFocus = (columns: { [id: string]: IColumn }) => {
   return resetFocusForStateColumns;
 };
 
-export const FeedbackBoard: React.FC<FeedbackBoardProps> = ({ displayBoard, board, team, workflowPhase, nonHiddenWorkItemTypes, focusModeNonHiddenWorkItemTypes, allWorkItemTypes, isAnonymous, hideFeedbackItems, onFocusModeModelChange, userId, onVoteCasted, onColumnNotesChange, scrollMode = "column" }) => {
+export const FeedbackBoard: React.FC<FeedbackBoardProps> = ({ displayBoard, board, team, workflowPhase, nonHiddenWorkItemTypes, focusModeNonHiddenWorkItemTypes, allWorkItemTypes, isAnonymous, hideFeedbackItems, onFocusModeModelChange, userId, currentUserIsTeamAdmin = false, onVoteCasted, onColumnNotesChange, scrollMode = "column" }) => {
   const trackActivity = useTrackMetric(reactPlugin, "FeedbackBoard");
 
   const [isDataLoaded, setIsDataLoaded] = useState(false);
@@ -228,6 +230,12 @@ export const FeedbackBoard: React.FC<FeedbackBoardProps> = ({ displayBoard, boar
     setActiveTimerFeedbackItemId(prev => getActiveTimerFeedbackItemIdAfterStop(prev, feedbackItemId));
   }, []);
 
+  const { canManageBoard } = getBoardAccess({
+    boardOwnerId: board.createdBy?.id,
+    currentUserId: userId,
+    isTeamAdmin: currentUserIsTeamAdmin,
+  });
+
   const addFeedbackItems = useCallback((columnId: string, feedbackItems: IFeedbackItemDocument[], shouldBroadcast: boolean, newlyCreated: boolean, showAddedAnimation: boolean, shouldHaveFocus: boolean, hideFeedbackItemsParam: boolean) => {
     setColumns(previousColumns => {
       const firstAddedItemId = feedbackItems.length && feedbackItems[0].id;
@@ -323,7 +331,7 @@ export const FeedbackBoard: React.FC<FeedbackBoardProps> = ({ displayBoard, boar
       nonHiddenWorkItemTypes: focusModeNonHiddenWorkItemTypes ?? nonHiddenWorkItemTypes,
       allWorkItemTypes,
       hideFeedbackItems,
-      isBoardOwner: board.createdBy?.id === userId,
+      canManageBoard,
       onVoteCasted: () => {
         onVoteCasted?.();
       },
@@ -334,7 +342,7 @@ export const FeedbackBoard: React.FC<FeedbackBoardProps> = ({ displayBoard, boar
       removeFeedbackItemFromColumn,
       refreshFeedbackItems,
     };
-  }, [columns, columnIds, workflowPhase, team, board.id, board.title, board.createdBy?.id, userId, defaultActionItemAreaPath, defaultActionItemIteration, nonHiddenWorkItemTypes, focusModeNonHiddenWorkItemTypes, allWorkItemTypes, hideFeedbackItems, onVoteCasted, activeTimerFeedbackItemId, requestTimerStart, handleTimerStopped, addFeedbackItems, removeFeedbackItemFromColumn, refreshFeedbackItems]);
+  }, [columns, columnIds, workflowPhase, team, board.id, board.title, focusModeNonHiddenWorkItemTypes, nonHiddenWorkItemTypes, allWorkItemTypes, hideFeedbackItems, canManageBoard, onVoteCasted, activeTimerFeedbackItemId, requestTimerStart, handleTimerStopped, addFeedbackItems, removeFeedbackItemFromColumn, refreshFeedbackItems, defaultActionItemAreaPath, defaultActionItemIteration]);
 
   const initColumns = useCallback(() => {
     const columnProperties = board.columns;
@@ -703,8 +711,6 @@ export const FeedbackBoard: React.FC<FeedbackBoardProps> = ({ displayBoard, boar
   }, [getFocusModeModel, onFocusModeModelChange]);
 
   const getFeedbackColumnPropsList = useCallback((): FeedbackColumnProps[] => {
-    const canCurrentUserEditBoard = board.createdBy?.id === userId;
-
     return columnIds.map((columnId, index) => {
       return {
         key: columnId,
@@ -729,12 +735,12 @@ export const FeedbackBoard: React.FC<FeedbackBoardProps> = ({ displayBoard, boar
         nonHiddenWorkItemTypes: nonHiddenWorkItemTypes,
         allWorkItemTypes: allWorkItemTypes,
         isBoardAnonymous: isAnonymous,
-        isBoardOwner: !!canCurrentUserEditBoard,
+        canManageBoard: canManageBoard,
         shouldFocusOnCreateFeedback: !!columns[columnId].shouldFocusOnCreateFeedback,
         hideFeedbackItems: hideFeedbackItems,
         isFocusModalHidden: true,
         groupIds: [] as string[],
-        showColumnEditButton: !!canCurrentUserEditBoard,
+        showColumnEditButton: canManageBoard,
         columnNotes: getColumnNotesOrEmpty(columnNotes, columnId),
         onColumnNotesChange: (notes: string) => handleColumnNotesChange(columnId, notes),
         onVoteCasted: () => {
@@ -747,7 +753,7 @@ export const FeedbackBoard: React.FC<FeedbackBoardProps> = ({ displayBoard, boar
         notifyTimerStopped: handleTimerStopped,
       };
     });
-  }, [board.createdBy?.id, board.id, board.title, userId, columnIds, columns, team, isDataLoaded, workflowPhase, addFeedbackItems, removeFeedbackItemFromColumn, refreshFeedbackItems, defaultActionItemAreaPath, defaultActionItemIteration, nonHiddenWorkItemTypes, allWorkItemTypes, isAnonymous, hideFeedbackItems, columnNotes, handleColumnNotesChange, onVoteCasted, activeTimerFeedbackItemId, requestTimerStart, handleTimerStopped]);
+  }, [columnIds, columns, team, board.id, board.title, isDataLoaded, workflowPhase, addFeedbackItems, removeFeedbackItemFromColumn, refreshFeedbackItems, defaultActionItemAreaPath, defaultActionItemIteration, nonHiddenWorkItemTypes, allWorkItemTypes, isAnonymous, hideFeedbackItems, canManageBoard, columnNotes, handleColumnNotesChange, onVoteCasted, activeTimerFeedbackItemId, requestTimerStart, handleTimerStopped]);
 
   if (!displayBoard) {
     return <div> An unexpected exception occurred. </div>;

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -2400,6 +2400,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
                     isAnonymous={state.currentBoard.isAnonymous ? state.currentBoard.isAnonymous : false}
                     hideFeedbackItems={state.currentBoard.shouldShowFeedbackAfterCollect ? state.currentBoard.activePhase == WorkflowPhase.Collect && state.currentBoard.shouldShowFeedbackAfterCollect : false}
                     userId={state.currentUserId}
+                    currentUserIsTeamAdmin={isCurrentUserTeamAdmin()}
                     onVoteCasted={updateCurrentVoteCount}
                     onColumnNotesChange={persistColumnNotes}
                     scrollMode={state.scrollMode}

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { IFeedbackBoardDocument, IFeedbackBoardDocumentPermissions } from "../interfaces/feedback";
 import { useTrackMetric } from "@microsoft/applicationinsights-react-js";
 import { reactPlugin } from "../utilities/telemetryClient";
+import { canCurrentUserManageBoard, isCurrentUserTeamAdmin } from "../utilities/boardAccessHelper";
 import { getIconElement } from "./icons";
 
 export interface IFeedbackBoardMetadataFormPermissionsProps {
@@ -35,9 +36,12 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
   const [selectAllChecked, setSelectAllChecked] = React.useState<boolean>(false);
   const [searchTerm, setSearchTerm] = React.useState<string>("");
 
-  const isBoardOwner = props.isNewBoardCreation || props.board?.createdBy?.id === props.currentUserId;
-  const isTeamAdmin = props.permissionOptions.some(option => option.id === props.currentUserId && option.isTeamAdmin);
-  const canEditPermissions = isBoardOwner || isTeamAdmin;
+  const canManageBoard = canCurrentUserManageBoard({
+    boardOwnerId: props.board?.createdBy?.id,
+    currentUserId: props.currentUserId,
+    isTeamAdmin: isCurrentUserTeamAdmin(props.currentUserId, props.permissionOptions),
+    isNewBoardCreation: props.isNewBoardCreation,
+  });
   const isGroupOption = (option: FeedbackBoardPermissionOption): boolean => {
     return /^\[[^\]]+\]\\/.test(option.name); // assumes groups have names like [project]\group
   };
@@ -46,7 +50,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
   const [filteredPermissionOptions, setFilteredPermissionOptions] = React.useState<FeedbackBoardPermissionOption[]>(cleanPermissionOptions);
 
   const handleSelectAllClicked = (checked: boolean) => {
-    if (!canEditPermissions) return;
+    if (!canManageBoard) return;
     const nextChecked = checked;
 
     if (nextChecked) {
@@ -61,7 +65,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
   };
 
   const handlePermissionClicked = (option: FeedbackBoardPermissionOption, hasPermission: boolean) => {
-    if (!canEditPermissions) return;
+    if (!canManageBoard) return;
 
     let permissionList: string[] = option.type === "team" ? teamPermissions : memberPermissions;
 
@@ -129,7 +133,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
   };
 
   const emitChangeEvent = () => {
-    if (canEditPermissions) {
+    if (canManageBoard) {
       props.onPermissionChanged({
         permissions: {
           Teams: teamPermissions,
@@ -156,7 +160,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
   };
 
   const PermissionEditWarning = () => {
-    if (!canEditPermissions) {
+    if (!canManageBoard) {
       return <div className="board-metadata-form-section-information">{getIconElement("exclamation")} Only the Board Owner or a Team Admin can edit permissions</div>;
     }
     return null;
@@ -195,7 +199,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
                     className="my-2"
                     id="select-all-permission-options-visible"
                     aria-label="Add permission to every team or member in the table."
-                    disabled={!canEditPermissions}
+                    disabled={!canManageBoard}
                     checked={selectAllChecked}
                     onChange={event => handleSelectAllClicked(event.target.checked)}
                     type="checkbox"

--- a/src/frontend/components/feedbackCarousel.tsx
+++ b/src/frontend/components/feedbackCarousel.tsx
@@ -24,7 +24,7 @@ export interface FocusModeModel {
   nonHiddenWorkItemTypes: WorkItemType[];
   allWorkItemTypes: WorkItemType[];
   hideFeedbackItems: boolean;
-  isBoardOwner?: boolean;
+  canManageBoard?: boolean;
   activeTimerFeedbackItemId: string | null;
   onVoteCasted: () => void;
   requestTimerStart: (feedbackItemId: string) => void;
@@ -206,7 +206,7 @@ export const FeedbackCarousel: React.FC<IFeedbackCarouselProps> = ({ focusModeMo
           shouldHaveFocus: columnItem.shouldHaveFocus,
           hideFeedbackItems: focusModeModel.hideFeedbackItems,
           userIdRef: columnItem.feedbackItem.userIdRef,
-          isBoardOwner: focusModeModel.isBoardOwner,
+          canManageBoard: focusModeModel.canManageBoard,
           onVoteCasted: focusModeModel.onVoteCasted,
           groupCount: columnItem.feedbackItem.childFeedbackItemIds ? columnItem.feedbackItem.childFeedbackItemIds.length : 0,
           groupIds: columnItem.feedbackItem.childFeedbackItemIds ?? [],

--- a/src/frontend/components/feedbackColumn.tsx
+++ b/src/frontend/components/feedbackColumn.tsx
@@ -33,7 +33,7 @@ export interface FeedbackColumnProps {
   nonHiddenWorkItemTypes: WorkItemType[];
   allWorkItemTypes: WorkItemType[];
   isBoardAnonymous: boolean;
-  isBoardOwner?: boolean;
+  canManageBoard?: boolean;
   shouldFocusOnCreateFeedback: boolean;
   hideFeedbackItems: boolean;
   groupIds: string[];
@@ -120,7 +120,7 @@ export const createFeedbackItemProps = (columnProps: FeedbackColumnProps, column
     shouldHaveFocus: columnItem.shouldHaveFocus,
     hideFeedbackItems: columnProps.hideFeedbackItems,
     userIdRef: columnItem.feedbackItem.userIdRef,
-    isBoardOwner: columnProps.isBoardOwner,
+    canManageBoard: columnProps.canManageBoard ?? false,
     onVoteCasted: columnProps.onVoteCasted,
     groupCount: columnItem.feedbackItem.childFeedbackItemIds ? columnItem.feedbackItem.childFeedbackItemIds.length : 0,
     groupIds: columnItem.feedbackItem.childFeedbackItemIds ?? [],

--- a/src/frontend/components/feedbackItem.tsx
+++ b/src/frontend/components/feedbackItem.tsx
@@ -557,7 +557,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
   }, [props.createdBy, props.createdByProfileImage, props.createdDate]);
 
   const deleteFeedbackItem = useCallback(() => {
-    // Only the feedback item's creator or a board manager (owner or Team Admin) may delete it.
+    // Only the feedback item's creator, the board owner, or a team admin may delete it.
     const canDelete = props.canManageBoard || props.userIdRef === getUserIdentity().id;
     if (!canDelete) {
       return;
@@ -746,7 +746,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
           if (target.tagName !== "BUTTON" && target.tagName !== "A") {
             const isOwnFeedbackItem = props.userIdRef === getUserIdentity().id;
             // Block entering edit mode when the card is obscured during collection, or when the
-            // current user is neither the creator nor a board manager (owner or Team Admin).
+            // current user is neither the creator, nor the board owner, nor a team admin.
             if ((props.hideFeedbackItems && !isOwnFeedbackItem) || (!isOwnFeedbackItem && !props.canManageBoard)) {
               e.preventDefault();
               return;
@@ -971,7 +971,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
   const totalItemsInColumn = numberedColumnItems.length;
 
   const hideFeedbackItems = props.workflowPhase === "Collect" && props.hideFeedbackItems && props.userIdRef !== getUserIdentity().id;
-  // A feedback card may only be edited or deleted by the user who created it or by a board manager.
+  // A feedback card may only be edited or deleted by the user who created it, the board owner, or a team admin.
   const canModifyFeedbackItem = props.canManageBoard || props.userIdRef === getUserIdentity().id;
   const creationDateFormatter = useMemo(() => new Intl.DateTimeFormat("default", { year: "numeric", month: "long", day: "numeric" }), []);
   const creationDateLabel = useMemo(() => {

--- a/src/frontend/components/feedbackItem.tsx
+++ b/src/frontend/components/feedbackItem.tsx
@@ -55,7 +55,7 @@ export interface IFeedbackItemProps {
   shouldHaveFocus: boolean;
   hideFeedbackItems: boolean;
   userIdRef: string;
-  isBoardOwner?: boolean;
+  canManageBoard: boolean;
   timerSecs: number;
   timerState: boolean;
   timerId: ReturnType<typeof setInterval> | null;
@@ -557,13 +557,13 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
   }, [props.createdBy, props.createdByProfileImage, props.createdDate]);
 
   const deleteFeedbackItem = useCallback(() => {
-    // Only the feedback item's creator or the board owner may delete it.
-    const canDelete = props.isBoardOwner || props.userIdRef === getUserIdentity().id;
+    // Only the feedback item's creator or a board manager (owner or Team Admin) may delete it.
+    const canDelete = props.canManageBoard || props.userIdRef === getUserIdentity().id;
     if (!canDelete) {
       return;
     }
     showDeleteItemConfirmationDialog();
-  }, [showDeleteItemConfirmationDialog, props.isBoardOwner, props.userIdRef]);
+  }, [showDeleteItemConfirmationDialog, props.canManageBoard, props.userIdRef]);
 
   const dragFeedbackItemOverFeedbackItem = useCallback(
     (
@@ -746,8 +746,8 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
           if (target.tagName !== "BUTTON" && target.tagName !== "A") {
             const isOwnFeedbackItem = props.userIdRef === getUserIdentity().id;
             // Block entering edit mode when the card is obscured during collection, or when the
-            // current user is neither the creator nor the board owner.
-            if ((props.hideFeedbackItems && !isOwnFeedbackItem) || (!isOwnFeedbackItem && !props.isBoardOwner)) {
+            // current user is neither the creator nor a board manager (owner or Team Admin).
+            if ((props.hideFeedbackItems && !isOwnFeedbackItem) || (!isOwnFeedbackItem && !props.canManageBoard)) {
               e.preventDefault();
               return;
             }
@@ -971,8 +971,8 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
   const totalItemsInColumn = numberedColumnItems.length;
 
   const hideFeedbackItems = props.workflowPhase === "Collect" && props.hideFeedbackItems && props.userIdRef !== getUserIdentity().id;
-  // A feedback card may only be edited or deleted by the user who created it or by the board owner.
-  const canModifyFeedbackItem = props.isBoardOwner || props.userIdRef === getUserIdentity().id;
+  // A feedback card may only be edited or deleted by the user who created it or by a board manager.
+  const canModifyFeedbackItem = props.canManageBoard || props.userIdRef === getUserIdentity().id;
   const creationDateFormatter = useMemo(() => new Intl.DateTimeFormat("default", { year: "numeric", month: "long", day: "numeric" }), []);
   const creationDateLabel = useMemo(() => {
     if (!props.createdDate) {
@@ -1257,7 +1257,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
               shouldHaveFocus: props.shouldHaveFocus,
               hideFeedbackItems: props.hideFeedbackItems,
               userIdRef: searchItem.userIdRef,
-              isBoardOwner: props.isBoardOwner,
+              canManageBoard: props.canManageBoard,
               timerSecs: searchItem.timerSecs,
               timerState: searchItem.timerState,
               timerId: searchItem.timerId,

--- a/src/frontend/components/whatsNewDialog.tsx
+++ b/src/frontend/components/whatsNewDialog.tsx
@@ -9,6 +9,7 @@ interface IWhatsNewDialogProps {
 const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.57 and v1.92.56 include:";
 
 const WHATS_NEW_ITEMS = [
+  "Extended permissions so team admins can also update column notes and edit or delete feedback cards.",
   "Improved hidden feedback behavior to display blurred feedback while announcing \"feedback blurred\".",
   "Added user settings to toggle between show all teams or my teams and to toggle between scrolling by board or by column.",
   "Added team admin setting for configuring available work item types in \"Add work item\".",

--- a/src/frontend/utilities/__tests__/boardAccessHelper.test.ts
+++ b/src/frontend/utilities/__tests__/boardAccessHelper.test.ts
@@ -1,0 +1,96 @@
+import { canCurrentUserManageBoard, getBoardAccess, isCurrentUserTeamAdmin } from "../boardAccessHelper";
+
+describe("boardAccessHelper", () => {
+  describe("isCurrentUserTeamAdmin", () => {
+    it("returns true when current user is marked as team admin", () => {
+      const result = isCurrentUserTeamAdmin("user-1", [
+        { id: "user-1", isTeamAdmin: true },
+        { id: "user-2", isTeamAdmin: false },
+      ]);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when current user is not a team admin", () => {
+      const result = isCurrentUserTeamAdmin("user-1", [
+        { id: "user-1", isTeamAdmin: false },
+        { id: "user-2", isTeamAdmin: true },
+      ]);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getBoardAccess", () => {
+    it("marks board owner correctly", () => {
+      const result = getBoardAccess({
+        boardOwnerId: "owner-1",
+        currentUserId: "owner-1",
+      });
+
+      expect(result).toEqual({
+        isBoardOwner: true,
+        isTeamAdmin: false,
+        canManageBoard: true,
+      });
+    });
+
+    it("allows team admin to manage board even when not owner", () => {
+      const result = getBoardAccess({
+        boardOwnerId: "owner-1",
+        currentUserId: "admin-1",
+        isTeamAdmin: true,
+      });
+
+      expect(result).toEqual({
+        isBoardOwner: false,
+        isTeamAdmin: true,
+        canManageBoard: true,
+      });
+    });
+
+    it("treats new board creation as owner context", () => {
+      const result = getBoardAccess({
+        boardOwnerId: undefined,
+        currentUserId: "user-1",
+        isNewBoardCreation: true,
+      });
+
+      expect(result).toEqual({
+        isBoardOwner: true,
+        isTeamAdmin: false,
+        canManageBoard: true,
+      });
+    });
+  });
+
+  describe("canCurrentUserManageBoard", () => {
+    it("returns true for board owner", () => {
+      const result = canCurrentUserManageBoard({
+        boardOwnerId: "owner-1",
+        currentUserId: "owner-1",
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("returns true for team admin", () => {
+      const result = canCurrentUserManageBoard({
+        boardOwnerId: "owner-1",
+        currentUserId: "admin-1",
+        isTeamAdmin: true,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when user is neither owner nor team admin", () => {
+      const result = canCurrentUserManageBoard({
+        boardOwnerId: "owner-1",
+        currentUserId: "member-1",
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/frontend/utilities/boardAccessHelper.ts
+++ b/src/frontend/utilities/boardAccessHelper.ts
@@ -1,0 +1,36 @@
+export interface IBoardAccessContext {
+  boardOwnerId?: string;
+  currentUserId: string;
+  isTeamAdmin?: boolean;
+  isNewBoardCreation?: boolean;
+}
+
+export interface IBoardAccess {
+  isBoardOwner: boolean;
+  isTeamAdmin: boolean;
+  canManageBoard: boolean;
+}
+
+export interface IUserPermissionOption {
+  id: string;
+  isTeamAdmin?: boolean;
+}
+
+export const isCurrentUserTeamAdmin = (currentUserId: string, permissionOptions: IUserPermissionOption[]): boolean => {
+  return permissionOptions.some(option => option.id === currentUserId && option.isTeamAdmin);
+};
+
+export const getBoardAccess = (context: IBoardAccessContext): IBoardAccess => {
+  const { boardOwnerId, currentUserId, isTeamAdmin = false, isNewBoardCreation = false } = context;
+  const isBoardOwner = isNewBoardCreation || boardOwnerId === currentUserId;
+
+  return {
+    isBoardOwner,
+    isTeamAdmin,
+    canManageBoard: isBoardOwner || isTeamAdmin,
+  };
+};
+
+export const canCurrentUserManageBoard = (context: IBoardAccessContext): boolean => {
+  return getBoardAccess(context).canManageBoard;
+};


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): ADO user story 3814

## Description

Extending column notes and card editting and deleting to team admin in addition to board owner.

Also addresses spelling issues in new release-promotion.prompt.md.

## Bug or Feature?

- [x] Bug fix
- [x] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly.
- [ ] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`, to be included with the next release.
  - [ ] I have included a link to this PR in that blurb.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both landscape and portrait views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.
