### PR TITLE
prevent double scrollbar for email summary

### DIFF
--- a/.github/workflows/ci_cd_frontend.yml
+++ b/.github/workflows/ci_cd_frontend.yml
@@ -85,70 +85,71 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/tbroadley/spellchecker-cli/ddb8f07599b5b15147168d3bcd8bbede0df8d2c7/dictionaries/base.txt
           echo "" >> base.txt
-          echo "azure-devops-extension-" >> base.txt
-          echo "parens" >> base.txt
-          echo "emailable" >> base.txt
+          echo "AdjustIcon" >> base.txt
+          echo "allowlist" >> base.txt
           echo "anonymize" >> base.txt
-          echo "pre-populated" >> base.txt
-          echo "favorability" >> base.txt
-          echo "Dev" >> base.txt
-          echo "tooltip" >> base.txt
-          echo "outloud" >> base.txt
-          echo "timebox" >> base.txt
-          echo "uncast" >> base.txt
-          echo "PRs" >> base.txt
-          echo "CodeCov" >> base.txt
+          echo "Async" >> base.txt
+          echo "azure-devops-extension-" >> base.txt
           echo "Backend" >> base.txt
-          echo "Pre-commit" >> base.txt
-          echo "SignalR" >> base.txt
-          echo "WIP" >> base.txt
-          echo "OKR" >> base.txt
-          echo "OKRs" >> base.txt
-          echo "CSV" >> base.txt
-          echo "SDK" >> base.txt
-          echo "GitHub" >> base.txt
-          echo "DevOps" >> base.txt
-          echo "Frontend" >> base.txt
-          echo "ERD" >> base.txt
+          echo "Bain" >> base.txt
+          echo "camelCase" >> base.txt
           echo "Changelog" >> base.txt
           echo "changelog" >> base.txt
-          echo "ReactTable" >> base.txt
-          echo "README" >> base.txt
-          echo "OpenSSF" >> base.txt
-          echo "Dependabot" >> base.txt
-          echo "lockfile" >> base.txt
-          echo "devDependency" >> base.txt
-          echo "roadmap" >> base.txt
           echo "CI_Backend" >> base.txt
-          echo "Moq" >> base.txt
-          echo "xUnit" >> base.txt
-          echo "Kanban" >> base.txt
+          echo "CodeCov" >> base.txt
+          echo "CSV" >> base.txt
+          echo "customizable" >> base.txt
+          echo "Dependabot" >> base.txt
+          echo "devDependency" >> base.txt
+          echo "Dev" >> base.txt
+          echo "DevOps" >> base.txt
+          echo "Edmondson" >> base.txt
+          echo "emailable" >> base.txt
           echo "enum" >> base.txt
-          echo "uncheck" >> base.txt
-          echo "unaggregated" >> base.txt
-          echo "gitleaks" >> base.txt
-          echo "ESNext" >> base.txt
+          echo "ERD" >> base.txt
           echo "ES2020" >> base.txt
+          echo "ESNext" >> base.txt
+          echo "favorability" >> base.txt
+          echo "favorability-band" >> base.txt
+          echo "Forsgren" >> base.txt
+          echo "Frontend" >> base.txt
+          echo "GitHub" >> base.txt
+          echo "gitleaks" >> base.txt
+          echo "hostname" >> base.txt
           echo "JSX" >> base.txt
-          echo "Async" >> base.txt
+          echo "Kanban" >> base.txt
+          echo "lockfile" >> base.txt
+          echo "memoizing" >> base.txt
+          echo "Moq" >> base.txt
+          echo "OKR" >> base.txt
+          echo "OKRs" >> base.txt
+          echo "on-prem" >> base.txt
+          echo "OpenSSF" >> base.txt
+          echo "outloud" >> base.txt
+          echo "parens" >> base.txt
           echo "PascalCase" >> base.txt
-          echo "camelCase" >> base.txt
+          echo "pre-populated" >> base.txt
+          echo "Pre-commit" >> base.txt
+          echo "PRs" >> base.txt
+          echo "README" >> base.txt
+          echo "ReactTable" >> base.txt
+          echo "reconnection" >> base.txt
+          echo "roadmap" >> base.txt
+          echo "scrollbar" >> base.txt
+          echo "SDK" >> base.txt
+          echo "SignalR" >> base.txt
+          echo "timebox" >> base.txt
+          echo "tooltip" >> base.txt
+          echo "unaggregated" >> base.txt
+          echo "uncast" >> base.txt
+          echo "uncheck" >> base.txt
           echo "useCallback" >> base.txt
           echo "useState" >> base.txt
-          echo "AdjustIcon" >> base.txt
-          echo "reconnection" >> base.txt
-          echo "ZTNA" >> base.txt
           echo "WebSocket" >> base.txt
-          echo "hostname" >> base.txt
-          echo "on-prem" >> base.txt
-          echo "allowlist" >> base.txt
-          echo "favorability-band" >> base.txt
-          echo "memoizing" >> base.txt
           echo "websocket" >> base.txt
-          echo "customizable" >> base.txt
-          echo "Bain" >> base.txt
-          echo "Edmondson" >> base.txt
-          echo "Forsgren" >> base.txt
+          echo "WIP" >> base.txt
+          echo "xUnit" >> base.txt
+          echo "ZTNA" >> base.txt
           npx -y spellchecker-cli --config ./.github/.spellcheckerrc.yaml
 
       - if: steps.changes.outputs.src == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ You can find the changelog of the Retrospective Extension below.
 
 ## v1.92.57
 
+* Fixed double-scrollbar behavior in the Create email summary dialog at higher zoom levels. From [GitHub PR #1816](https://github.com/microsoft/vsts-extension-retrospectives/pull/1816)
 * Extended permissions so board owners and team admins can update column notes and edit or delete feedback cards. From [GitHub PR #1805](https://github.com/microsoft/vsts-extension-retrospectives/pull/1805)
 * Improved hidden feedback behavior so screen displays blurred feedback and screen reader announces "feedback blurred". From [GitHub PR #1796](https://github.com/microsoft/vsts-extension-retrospectives/pull/1796)
+* Updated toast rendering so notifications appear within the topmost open dialog. From [GitHub PR #1794](https://github.com/microsoft/vsts-extension-retrospectives/pull/1794)
+* Fixed Copy to clipboard behavior for the email summary experience. From [GitHub PR #1793](https://github.com/microsoft/vsts-extension-retrospectives/pull/1793)
+* Added release-promotion guidelines documentation to support consistent release workflows. From [GitHub PR #1792](https://github.com/microsoft/vsts-extension-retrospectives/pull/1792)
 
 ## v1.92.56
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ You can find the changelog of the Retrospective Extension below.
 
 ## v1.92.57
 
-* Fixed double-scrollbar behavior in the Create email summary dialog at higher zoom levels. From [GitHub PR #1816](https://github.com/microsoft/vsts-extension-retrospectives/pull/1816)
+* Fixed double scrollbar behavior in the Create email summary dialog at higher zoom levels. From [GitHub PR #1816](https://github.com/microsoft/vsts-extension-retrospectives/pull/1816)
 * Extended permissions so board owners and team admins can update column notes and edit or delete feedback cards. From [GitHub PR #1805](https://github.com/microsoft/vsts-extension-retrospectives/pull/1805)
 * Improved hidden feedback behavior so screen displays blurred feedback and screen reader announces "feedback blurred". From [GitHub PR #1796](https://github.com/microsoft/vsts-extension-retrospectives/pull/1796)
 * Updated toast rendering so notifications appear within the topmost open dialog. From [GitHub PR #1794](https://github.com/microsoft/vsts-extension-retrospectives/pull/1794)

--- a/src/frontend/components/whatsNewDialog.tsx
+++ b/src/frontend/components/whatsNewDialog.tsx
@@ -9,6 +9,7 @@ interface IWhatsNewDialogProps {
 const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.57 and v1.92.56 include:";
 
 const WHATS_NEW_ITEMS = [
+  "Fixed the email summary Copy to clipboard action so it works reliably from the preview dialog.",
   "Extended permissions so team admins can also update column notes and edit or delete feedback cards.",
   "Improved hidden feedback behavior to display blurred feedback while announcing \"feedback blurred\".",
   "Added user settings to toggle between show all teams or my teams and to toggle between scrolling by board or by column.",

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -533,7 +533,15 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
 }
 
 .preview-email-content {
-  @apply w-full p-2;
+  @apply w-full h-full p-2 resize-none overflow-y-auto;
+}
+
+.preview-email-dialog {
+  @apply flex flex-col overflow-hidden;
+
+  & .subText {
+    @apply flex-1 min-h-0;
+  }
 }
 
 .choose-feedback-column-icon-button {

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -533,14 +533,14 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
 }
 
 .preview-email-content {
-  @apply w-full h-full p-2 resize-none overflow-y-auto;
+  @apply w-full flex-1 min-h-0 p-2 resize-none overflow-y-auto box-border;
 }
 
 .preview-email-dialog {
   @apply flex flex-col overflow-hidden;
 
   & .subText {
-    @apply flex-1 min-h-0;
+    @apply flex flex-1 min-h-0 overflow-hidden;
   }
 }
 


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): ADO Bug 3855 

## Description

Prevents double scrollbar for email summary dialog.
Also updates changelog and what's new for pull requests 1792, 1793, and 1794.

## Bug or Feature?

- [x] Bug fix
- [ ] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated any relevant documentation accordingly.
- [x] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`, to be included with the next release.
  - [x] I have included a link to this PR in that blurb.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both portrait and landscape views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs
