### PR TITLE
fix: stabilize focusModeModel callback to stop re-render loop

### DIFF
--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1942,6 +1942,10 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     setContainerState(previousState => ({ ...previousState, ...voteMetricsState }));
   }, [getVoteMetricsState]);
 
+  const handleFocusModeModelChange = React.useCallback((focusModeModel: FocusModeModel) => {
+    setContainerState(previousState => ({ ...previousState, focusModeModel }));
+  }, []);
+
   const updateBoardAndBroadcast = (updatedBoard: IFeedbackBoardDocument) => {
     if (!updatedBoard) {
       void handleBoardDeleted(state.currentTeam.id, state.currentBoard.id);
@@ -2595,9 +2599,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
                     nonHiddenWorkItemTypes={state.nonHiddenWorkItemTypes}
                     focusModeNonHiddenWorkItemTypes={state.focusModeNonHiddenWorkItemTypes}
                     allWorkItemTypes={state.allWorkItemTypes}
-                    onFocusModeModelChange={focusModeModel => {
-                      setContainerState(previousState => ({ ...previousState, focusModeModel }));
-                    }}
+                    onFocusModeModelChange={handleFocusModeModelChange}
                     isAnonymous={state.currentBoard.isAnonymous ? state.currentBoard.isAnonymous : false}
                     hideFeedbackItems={state.currentBoard.shouldShowFeedbackAfterCollect ? state.currentBoard.activePhase == WorkflowPhase.Collect && state.currentBoard.shouldShowFeedbackAfterCollect : false}
                     userId={state.currentUserId}


### PR DESCRIPTION
## Summary
- Stabilize `onFocusModeModelChange` with `useCallback` in `FeedbackBoardContainer` so `FeedbackBoard`'s focus-mode effect no longer re-fires on every parent render.
- Fixes an infinite re-render loop that kept the board busy and drove high CPU / sluggishness while idle.

Fixes #1823

## Test plan
- [ ] Open a retrospectives board and confirm idle CPU stays low (no continuous re-render spin)
- [ ] Enter/exit focus mode and confirm carousel still updates as items change
- [ ] Cast votes / move items and confirm focus mode model stays in sync
- [x] Run frontend tests: `npm test` from `src/frontend`
