### PR TITLE
Remove good to done (1-1) template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ From [GitHub PR #1835](https://github.com/microsoft/vsts-extension-retrospective
 
 From [GitHub PR #1832](https://github.com/microsoft/vsts-extension-retrospectives/pull/1832)
 
+* Removed rarely used Good-to-Done retrospective template. From [GitHub PR #1845](https://github.com/microsoft/vsts-extension-retrospectives/pull/1845)
+
 ## v1.92.57
 
 * Fixed double scrollbar behavior in the Create email summary dialog at higher zoom levels. From [GitHub PR #1816](https://github.com/microsoft/vsts-extension-retrospectives/pull/1816)

--- a/src/frontend/components/__tests__/feedbackBoardMetadataForm.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataForm.test.tsx
@@ -2041,7 +2041,7 @@ describe("FeedbackBoardMetadataForm - Template Selection Extended", () => {
 
     const templateDropdown = screen.getByLabelText(/apply template/i) as HTMLSelectElement;
 
-    const templates = ["start-stop-continue", "good-improve-ideas-thanks", "mad-sad-glad", "4ls", "daki", "kalm", "wlai", "1to1", "speedboat", "clarity", "energy", "psy-safety", "wlb", "confidence", "efficiency"];
+    const templates = ["start-stop-continue", "good-improve-ideas-thanks", "mad-sad-glad", "4ls", "daki", "kalm", "wlai", "speedboat", "clarity", "energy", "psy-safety", "wlb", "confidence", "efficiency"];
 
     for (const template of templates) {
       await user.selectOptions(templateDropdown, template);

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -414,7 +414,6 @@ export const FeedbackBoardMetadataForm: React.FC<IFeedbackBoardMetadataFormProps
                   <option value="daki">Drop-Add-Keep-Improve</option>
                   <option value="kalm">Keep-Add-Less-More</option>
                   <option value="wlai">Went Well-Learned-Accelerators-Impediments</option>
-                  <option value="1to1">Good-to-Done</option>
                   <option value="speedboat">Speedboat</option>
                   <option disabled>─────────────</option>
                   <option value="clarity">Clarity</option>

--- a/src/frontend/utilities/__tests__/boardColumnsHelper.test.tsx
+++ b/src/frontend/utilities/__tests__/boardColumnsHelper.test.tsx
@@ -256,42 +256,6 @@ describe("boardColumnsHelper", () => {
       });
     });
 
-    describe("1to1 template", () => {
-      it("should return correct columns for 1to1 template (1-to-1 feedback)", () => {
-        const result = getColumnsByTemplateId("1to1");
-
-        expect(result).toHaveLength(4);
-        expect(result[0]).toEqual({
-          accentColor: "#008000",
-          iconClass: "thumb-up",
-          id: "uuid-1",
-          title: "Good",
-          notes: "",
-        });
-        expect(result[1]).toEqual({
-          accentColor: "#f6af08",
-          iconClass: "thumb-up-down",
-          id: "uuid-2",
-          title: "So-so",
-          notes: "",
-        });
-        expect(result[2]).toEqual({
-          accentColor: "#cc293d",
-          iconClass: "thumb-down",
-          id: "uuid-3",
-          title: "Not-so-good",
-          notes: "",
-        });
-        expect(result[3]).toEqual({
-          accentColor: "#8063bf",
-          iconClass: "check-circle",
-          id: "uuid-4",
-          title: "Done",
-          notes: "",
-        });
-      });
-    });
-
     describe("speedboat template", () => {
       it("should return correct columns for speedboat template (Propellors, Lifesavers, Anchors, Rocks)", () => {
         const result = getColumnsByTemplateId("speedboat");
@@ -588,7 +552,7 @@ describe("boardColumnsHelper", () => {
 
     describe("column structure validation", () => {
       it("should ensure all columns have required IFeedbackColumn properties", () => {
-        const templateIds = ["start-stop-continue", "good-improve-ideas-thanks", "mad-sad-glad", "4ls", "daki", "kalm", "wlai", "1to1", "speedboat", "clarity", "energy", "psy-safety", "wlb", "confidence", "efficiency", "unknown-template"];
+        const templateIds = ["start-stop-continue", "good-improve-ideas-thanks", "mad-sad-glad", "4ls", "daki", "kalm", "wlai", "speedboat", "clarity", "energy", "psy-safety", "wlb", "confidence", "efficiency", "unknown-template"];
 
         templateIds.forEach(templateId => {
           // Reset mock for each iteration
@@ -654,7 +618,7 @@ describe("boardColumnsHelper", () => {
 
     describe("icon validation", () => {
       it("should provide a valid React icon element", () => {
-        const allTemplates = ["start-stop-continue", "good-improve-ideas-thanks", "mad-sad-glad", "4ls", "daki", "kalm", "wlai", "1to1", "speedboat"];
+        const allTemplates = ["start-stop-continue", "good-improve-ideas-thanks", "mad-sad-glad", "4ls", "daki", "kalm", "wlai", "speedboat"];
 
         allTemplates.forEach(templateId => {
           const result = getColumnsByTemplateId(templateId);

--- a/src/frontend/utilities/boardColumnsHelper.tsx
+++ b/src/frontend/utilities/boardColumnsHelper.tsx
@@ -208,37 +208,6 @@ export const getColumnsByTemplateId = (templateId: string): IFeedbackColumn[] =>
           notes: "",
         },
       ];
-    case "1to1": // 1-to-1 - Good, So-so, Not-so-good, Done
-      return [
-        {
-          accentColor: "#008000", //green
-          iconClass: "thumb-up",
-          id: generateUUID(),
-          title: "Good",
-          notes: "",
-        },
-        {
-          accentColor: "#f6af08", //yellow
-          iconClass: "thumb-up-down",
-          id: generateUUID(),
-          title: "So-so",
-          notes: "",
-        },
-        {
-          accentColor: "#cc293d", //red
-          iconClass: "thumb-down",
-          id: generateUUID(),
-          title: "Not-so-good",
-          notes: "",
-        },
-        {
-          accentColor: "#8063bf", //purple
-          iconClass: "check-circle",
-          id: generateUUID(),
-          title: "Done",
-          notes: "",
-        },
-      ];
     case "speedboat": // Speedboat retrospective - Propellers, Life Preserver, Anchors, Rocks
       return [
         {


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): ADO Task 3464

## Description

Remove good-to-done (1-1) template which has minimal to no usage.

## Bug or Feature?

- [ ] Bug fix
- [x] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly.
- [x] I have added either the `docs updated` or `docs not needed` label to this PR.
- [ ] If I used `docs updated`, I updated the relevant release-facing content, such as `CHANGELOG.md`, What's New, `README.md`, or `src/frontend/assets/PACKAGE-DESCRIPTION.md`.
  - [ ] If I updated `CHANGELOG.md`, I included a link to this PR in that blurb.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

<!-- Do you have any screenshots or logs that would show off your fix? -->
