### PR TITLE
increase permission retrival limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ You can find the changelog of the Retrospective Extension below.
 
 ## v1.92.60
 
-* Prioritized permissions to include board owner, users and teams granted permission, current team and current team members, plus additional project members and teams within hard caps of 500 users and 100 teams. From [GitHub PR #1866](https://github.com/microsoft/vsts-extension-retrospectives/pull/1866)
+* Prioritized permissions to include board owner, users and teams granted permission, current team and current team members, plus additional project members and teams within hard caps of 200 users and 100 teams. From [GitHub PR #1866](https://github.com/microsoft/vsts-extension-retrospectives/pull/1866)
 
 ## v1.92.59
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 You can find the changelog of the Retrospective Extension below.
 
+## v1.92.60
+
+* Prioritized permissions to include board owner, users and teams granted permission, current team and current team members, plus additional project members and teams within hard caps of 500 users and 100 teams. From [GitHub PR #1866](https://github.com/microsoft/vsts-extension-retrospectives/pull/1866)
+
 ## v1.92.59
 
 * Added a "Move Everyone" control so board managers can move all participants to the selected retrospective phase. From [GitHub PR #1836](https://github.com/microsoft/vsts-extension-retrospectives/pull/1836)
@@ -11,10 +15,10 @@ You can find the changelog of the Retrospective Extension below.
 * Optimized board, permission, workflow-stage, and Team Assessment History rendering to reduce unnecessary updates. From [GitHub PR #1840](https://github.com/microsoft/vsts-extension-retrospectives/pull/1840)
 * Improved the board settings dialog layout and accessibility, including dialog sizing and tab structure. From [GitHub PR #1833](https://github.com/microsoft/vsts-extension-retrospectives/pull/1833)
 * Refined board settings inputs, selector options, and tooltip positioning for a more consistent interface. From [GitHub PR #1841](https://github.com/microsoft/vsts-extension-retrospectives/pull/1841)
+
 * Restricted editing of retrospective settings to the Board Owner or a Team Admin.
 * Added a view-only retrospective settings experience for other users, including updated board menu text, dialog messaging, and disabled editing controls.
 * Fixed bug that prevented saving retrospective settings from the Permissions tab.
-* Hardened frontend CI/CD pipeline by retrying publish once on transient failure.
 
 From [GitHub PR #1846](https://github.com/microsoft/vsts-extension-retrospectives/pull/1846)
 

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -377,12 +377,13 @@ describe("buildPermissionOptions", () => {
 
     const allMembers: TeamMember[] = [
       { identity: { id: "group-1", displayName: "[Project]\\Contributors", uniqueName: "[Project]\\Contributors" } as IdentityRef } as TeamMember,
-      { identity: { id: "user-1", displayName: "User 1", uniqueName: "user1@example.com" } as IdentityRef } as TeamMember,
-      { identity: { id: "user-2", displayName: "User 2", uniqueName: "user2@example.com" } as IdentityRef } as TeamMember,
-      { identity: { id: "user-3", displayName: "User 3", uniqueName: "user3@example.com" } as IdentityRef } as TeamMember,
-      { identity: { id: "user-4", displayName: "User 4", uniqueName: "user4@example.com" } as IdentityRef } as TeamMember,
-      { identity: { id: "user-5", displayName: "User 5", uniqueName: "user5@example.com" } as IdentityRef } as TeamMember,
-      { identity: { id: "user-6", displayName: "User 6", uniqueName: "user6@example.com" } as IdentityRef } as TeamMember,
+      ...Array.from({ length: 501 }, (_, index) => ({
+        identity: {
+          id: `user-${index + 1}`,
+          displayName: `User ${index + 1}`,
+          uniqueName: `user${index + 1}@example.com`,
+        } as IdentityRef,
+      })) as TeamMember[],
     ];
 
     const result = buildPermissionOptions({
@@ -410,7 +411,7 @@ describe("buildPermissionOptions", () => {
     });
 
     const memberOptions = result.permissionOptions.filter(option => option.type === "member");
-    expect(memberOptions).toHaveLength(6);
+    expect(memberOptions).toHaveLength(501);
     expect(memberOptions.some(option => option.id === "group-1")).toBe(false);
     expect(result.hasReachedUserLimit).toBe(true);
   });
@@ -419,7 +420,7 @@ describe("buildPermissionOptions", () => {
     const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
     const boardOwner = { id: "user-1", displayName: "User 1", uniqueName: "user1@example.com" } as IdentityRef;
 
-    const currentTeamMembers: TeamMember[] = Array.from({ length: 7 }, (_, index) => ({
+    const currentTeamMembers: TeamMember[] = Array.from({ length: 501 }, (_, index) => ({
       identity: {
         id: `user-${index + 1}`,
         displayName: `User ${index + 1}`,
@@ -459,7 +460,7 @@ describe("buildPermissionOptions", () => {
     });
 
     const memberOptions = result.permissionOptions.filter(option => option.type === "member");
-    expect(memberOptions).toHaveLength(7);
+    expect(memberOptions).toHaveLength(501);
     expect(memberOptions.some(option => option.id === "other-1")).toBe(false);
     expect(memberOptions.some(option => option.id === "other-2")).toBe(false);
     expect(result.hasReachedUserLimit).toBe(true);
@@ -550,7 +551,7 @@ describe("buildPermissionOptions", () => {
     const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
     const boardOwner = { id: "owner-1", displayName: "Owner User", uniqueName: "owner@example.com" } as IdentityRef;
 
-    const currentTeamMembers: TeamMember[] = Array.from({ length: 5 }, (_, index) => ({
+    const currentTeamMembers: TeamMember[] = Array.from({ length: 500 }, (_, index) => ({
       identity: {
         id: `member-${index + 1}`,
         displayName: `Member ${index + 1}`,

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -410,7 +410,7 @@ describe("buildPermissionOptions", () => {
     });
 
     const memberOptions = result.permissionOptions.filter(option => option.type === "member");
-    expect(memberOptions).toHaveLength(7);
+    expect(memberOptions).toHaveLength(6);
     expect(memberOptions.some(option => option.id === "group-1")).toBe(false);
     expect(result.hasReachedUserLimit).toBe(true);
   });
@@ -459,10 +459,10 @@ describe("buildPermissionOptions", () => {
     });
 
     const memberOptions = result.permissionOptions.filter(option => option.type === "member");
-    expect(memberOptions).toHaveLength(9);
-    expect(memberOptions.some(option => option.id === "other-1")).toBe(true);
-    expect(memberOptions.some(option => option.id === "other-2")).toBe(true);
-    expect(result.hasReachedUserLimit).toBe(false);
+    expect(memberOptions).toHaveLength(7);
+    expect(memberOptions.some(option => option.id === "other-1")).toBe(false);
+    expect(memberOptions.some(option => option.id === "other-2")).toBe(false);
+    expect(result.hasReachedUserLimit).toBe(true);
   });
 });
 
@@ -751,11 +751,11 @@ describe("FeedbackBoardContainer integration", () => {
   });
 
   it("shows all project teams in the team selector when enabled from settings", async () => {
-    const otherTeam = { ...mockTeam, id: "t2", name: "Other Team" };
+    const otherTeams = Array.from({ length: 8 }, (_, index) => ({ ...mockTeam, id: `t${index + 2}`, name: `Other Team ${index + 2}` }));
 
     mocked(getService).mockResolvedValue({ getHash: jest.fn().mockResolvedValue(""), setHash: jest.fn() } as any);
     mocked(azureDevOpsCoreService.getAllTeams).mockImplementation(async (_projectId, forCurrentUserOnly) =>
-      forCurrentUserOnly ? [mockTeam as WebApiTeam] : [mockTeam as WebApiTeam, otherTeam as WebApiTeam],
+      forCurrentUserOnly ? [mockTeam as WebApiTeam] : ([mockTeam as WebApiTeam, ...otherTeams] as WebApiTeam[]),
     );
     mocked(azureDevOpsCoreService.getDefaultTeam).mockResolvedValue(mockTeam as WebApiTeam);
     mocked(azureDevOpsCoreService.getMembers).mockResolvedValue([]);
@@ -831,7 +831,16 @@ describe("FeedbackBoardContainer integration", () => {
     fireEvent.click(screen.getByRole("button", { name: "Show all teams" }));
 
     expect(azureDevOpsCoreService.getAllTeams).toHaveBeenCalledWith("1", false);
-    expect(await screen.findByRole("option", { name: "Other Team" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "Other Team 2" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Other Team 6" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "User/Admin Settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show my teams" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "Team 1" })).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "Other Team 2" })).not.toBeInTheDocument();
+    });
   });
 
   it("configures a custom tooltip for Team Assessment", async () => {

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -545,6 +545,62 @@ describe("buildPermissionOptions", () => {
     expect(currentUserOption?.isTeamAdmin).toBe(true);
     expect(currentUserOption?.thumbnailUrl).toBe("https://example.com/admin.png");
   });
+
+  it("marks current user as team admin even when additional member allowance is exhausted", () => {
+    const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
+    const boardOwner = { id: "owner-1", displayName: "Owner User", uniqueName: "owner@example.com" } as IdentityRef;
+
+    const currentTeamMembers: TeamMember[] = Array.from({ length: 5 }, (_, index) => ({
+      identity: {
+        id: `member-${index + 1}`,
+        displayName: `Member ${index + 1}`,
+        uniqueName: `member${index + 1}@example.com`,
+      } as IdentityRef,
+      isTeamAdmin: false,
+    })) as TeamMember[];
+
+    const allMembers: TeamMember[] = [
+      ...currentTeamMembers,
+      {
+        identity: {
+          id: "admin-user",
+          displayName: "Admin User",
+          uniqueName: "admin@example.com",
+        } as IdentityRef,
+        isTeamAdmin: true,
+      } as TeamMember,
+    ];
+
+    const result = buildPermissionOptions({
+      board: {
+        id: "b1",
+        title: "Board 1",
+        createdDate: new Date(),
+        createdBy: boardOwner,
+        permissions: { Teams: [], Members: [] },
+        boardVoteCollection: {},
+        isIncludeTeamEffectivenessMeasurement: false,
+        shouldShowFeedbackAfterCollect: false,
+        isAnonymous: false,
+        activePhase: WorkflowPhase.Collect,
+        teamId: "t1",
+        maxVotesPerUser: 5,
+        teamEffectivenessMeasurementVoteCollection: [],
+        columns: [],
+      },
+      currentUserId: "admin-user",
+      currentUserIsTeamAdmin: true,
+      isNewBoardCreation: false,
+      currentTeam,
+      projectTeams: [currentTeam],
+      currentTeamMembers,
+      allMembers,
+    });
+
+    const currentUserOption = result.permissionOptions.find(option => option.type === "member" && option.id === "admin-user");
+    expect(currentUserOption).toBeDefined();
+    expect(currentUserOption?.isTeamAdmin).toBe(true);
+  });
 });
 
 describe("FeedbackBoardContainer integration", () => {

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -413,7 +413,7 @@ describe("buildPermissionOptions", () => {
     const memberOptions = result.permissionOptions.filter(option => option.type === "member");
     expect(memberOptions).toHaveLength(501);
     expect(memberOptions.some(option => option.id === "group-1")).toBe(false);
-    expect(result.hasReachedUserLimit).toBe(true);
+    expect(result.hasReachedUserLimit).toBe(false);
   });
 
   it("includes all current-team users before applying additional user cap", () => {

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -515,6 +515,90 @@ describe("buildPermissionOptions", () => {
     expect(result.hasReachedUserLimit).toBe(false);
   });
 
+  it("includes my-team members beyond the current team in the additional user pool", () => {
+    const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
+    const myOtherTeam = { id: "my-other-team", name: "My Other Team", projectName: "Project" } as WebApiTeam;
+    const boardOwner = { id: "owner-1", displayName: "Owner User", uniqueName: "owner@example.com" } as IdentityRef;
+
+    const currentTeamMembers: TeamMember[] = [
+      { identity: { ...baseIdentity, id: "current-1", displayName: "Current 1", uniqueName: "current1@example.com" } as IdentityRef } as TeamMember,
+    ];
+
+    const allMembers: TeamMember[] = [
+      ...currentTeamMembers,
+      { identity: { ...baseIdentity, id: "my-team-1", displayName: "My Team 1", uniqueName: "myteam1@example.com" } as IdentityRef } as TeamMember,
+    ];
+
+    const result = buildPermissionOptions({
+      board: {
+        id: "b1",
+        title: "Board 1",
+        createdDate: new Date(),
+        createdBy: boardOwner,
+        permissions: { Teams: [], Members: [] },
+        boardVoteCollection: {},
+        isIncludeTeamEffectivenessMeasurement: false,
+        shouldShowFeedbackAfterCollect: false,
+        isAnonymous: false,
+        activePhase: WorkflowPhase.Collect,
+        teamId: "t1",
+        maxVotesPerUser: 5,
+        teamEffectivenessMeasurementVoteCollection: [],
+        columns: [],
+      },
+      currentUserId: boardOwner.id,
+      isNewBoardCreation: false,
+      currentTeam,
+      projectTeams: [currentTeam, myOtherTeam],
+      currentTeamMembers,
+      allMembers,
+    });
+
+    expect(result.permissionOptions.some(option => option.id === "my-team-1" && option.type === "member")).toBe(true);
+    expect(result.hasReachedUserLimit).toBe(false);
+  });
+
+  it("always includes permission-checked teams before capping additional teams", () => {
+    const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
+    const boardOwner = { id: "owner-1", displayName: "Owner User", uniqueName: "owner@example.com" } as IdentityRef;
+    const permissionTeamIds = Array.from({ length: 105 }, (_, index) => `required-team-${index + 1}`);
+    const projectTeams = [
+      currentTeam,
+      ...permissionTeamIds.map((id, index) => ({ id, name: `Required Team ${index + 1}`, projectName: "Project" } as WebApiTeam)),
+      ...Array.from({ length: 10 }, (_, index) => ({ id: `optional-team-${index + 1}`, name: `Optional Team ${index + 1}`, projectName: "Project" } as WebApiTeam)),
+    ];
+
+    const result = buildPermissionOptions({
+      board: {
+        id: "b1",
+        title: "Board 1",
+        createdDate: new Date(),
+        createdBy: boardOwner,
+        permissions: { Teams: permissionTeamIds, Members: [] },
+        boardVoteCollection: {},
+        isIncludeTeamEffectivenessMeasurement: false,
+        shouldShowFeedbackAfterCollect: false,
+        isAnonymous: false,
+        activePhase: WorkflowPhase.Collect,
+        teamId: "t1",
+        maxVotesPerUser: 5,
+        teamEffectivenessMeasurementVoteCollection: [],
+        columns: [],
+      },
+      currentUserId: boardOwner.id,
+      isNewBoardCreation: false,
+      currentTeam,
+      projectTeams,
+      currentTeamMembers: [],
+      allMembers: [],
+    });
+
+    const teamOptionIds = result.permissionOptions.filter(option => option.type === "team").map(option => option.id);
+    expect(permissionTeamIds.every(teamId => teamOptionIds.includes(teamId))).toBe(true);
+    expect(teamOptionIds.includes("optional-team-1")).toBe(false);
+    expect(result.hasReachedTeamLimit).toBe(true);
+  });
+
   it("includes the current user when they are not the owner and not a team member", () => {
     const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
     const boardOwner = { id: "owner-1", displayName: "Owner User", uniqueName: "owner@example.com" } as IdentityRef;

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -498,6 +498,53 @@ describe("buildPermissionOptions", () => {
     expect(memberOptions.some(option => option.id === "admin-user")).toBe(true);
     expect(memberOptions.some(option => option.id === "owner-1")).toBe(true);
   });
+
+  it("marks injected current user as team admin when admin metadata is available", () => {
+    const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
+    const boardOwner = { id: "owner-1", displayName: "Owner User", uniqueName: "owner@example.com" } as IdentityRef;
+
+    const allMembers: TeamMember[] = [
+      {
+        identity: {
+          id: "admin-user",
+          displayName: "Admin User",
+          uniqueName: "admin@example.com",
+          imageUrl: "https://example.com/admin.png",
+        } as IdentityRef,
+        isTeamAdmin: true,
+      } as TeamMember,
+    ];
+
+    const result = buildPermissionOptions({
+      board: {
+        id: "b1",
+        title: "Board 1",
+        createdDate: new Date(),
+        createdBy: boardOwner,
+        permissions: { Teams: [], Members: [] },
+        boardVoteCollection: {},
+        isIncludeTeamEffectivenessMeasurement: false,
+        shouldShowFeedbackAfterCollect: false,
+        isAnonymous: false,
+        activePhase: WorkflowPhase.Collect,
+        teamId: "t1",
+        maxVotesPerUser: 5,
+        teamEffectivenessMeasurementVoteCollection: [],
+        columns: [],
+      },
+      currentUserId: "admin-user",
+      isNewBoardCreation: false,
+      currentTeam,
+      projectTeams: [currentTeam],
+      currentTeamMembers: [],
+      allMembers,
+    });
+
+    const currentUserOption = result.permissionOptions.find(option => option.type === "member" && option.id === "admin-user");
+    expect(currentUserOption).toBeDefined();
+    expect(currentUserOption?.isTeamAdmin).toBe(true);
+    expect(currentUserOption?.thumbnailUrl).toBe("https://example.com/admin.png");
+  });
 });
 
 describe("FeedbackBoardContainer integration", () => {

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -377,7 +377,7 @@ describe("buildPermissionOptions", () => {
 
     const allMembers: TeamMember[] = [
       { identity: { id: "group-1", displayName: "[Project]\\Contributors", uniqueName: "[Project]\\Contributors" } as IdentityRef } as TeamMember,
-      ...Array.from({ length: 501 }, (_, index) => ({
+      ...Array.from({ length: 500 }, (_, index) => ({
         identity: {
           id: `user-${index + 1}`,
           displayName: `User ${index + 1}`,

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -832,7 +832,7 @@ describe("FeedbackBoardContainer integration", () => {
 
     expect(azureDevOpsCoreService.getAllTeams).toHaveBeenCalledWith("1", false);
     expect(await screen.findByRole("option", { name: "Other Team 2" })).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: "Other Team 6" })).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Other Team 6" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "User/Admin Settings" }));
     fireEvent.click(screen.getByRole("button", { name: "Show my teams" }));

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -410,7 +410,7 @@ describe("buildPermissionOptions", () => {
     });
 
     const memberOptions = result.permissionOptions.filter(option => option.type === "member");
-    expect(memberOptions).toHaveLength(6);
+    expect(memberOptions).toHaveLength(7);
     expect(memberOptions.some(option => option.id === "group-1")).toBe(false);
     expect(result.hasReachedUserLimit).toBe(true);
   });
@@ -459,10 +459,10 @@ describe("buildPermissionOptions", () => {
     });
 
     const memberOptions = result.permissionOptions.filter(option => option.type === "member");
-    expect(memberOptions).toHaveLength(7);
-    expect(memberOptions.some(option => option.id === "other-1")).toBe(false);
-    expect(memberOptions.some(option => option.id === "other-2")).toBe(false);
-    expect(result.hasReachedUserLimit).toBe(true);
+    expect(memberOptions).toHaveLength(9);
+    expect(memberOptions.some(option => option.id === "other-1")).toBe(true);
+    expect(memberOptions.some(option => option.id === "other-2")).toBe(true);
+    expect(result.hasReachedUserLimit).toBe(false);
   });
 });
 

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -464,6 +464,40 @@ describe("buildPermissionOptions", () => {
     expect(memberOptions.some(option => option.id === "other-2")).toBe(false);
     expect(result.hasReachedUserLimit).toBe(true);
   });
+
+  it("includes the current user when they are not the owner and not a team member", () => {
+    const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
+    const boardOwner = { id: "owner-1", displayName: "Owner User", uniqueName: "owner@example.com" } as IdentityRef;
+
+    const result = buildPermissionOptions({
+      board: {
+        id: "b1",
+        title: "Board 1",
+        createdDate: new Date(),
+        createdBy: boardOwner,
+        permissions: { Teams: [], Members: [] },
+        boardVoteCollection: {},
+        isIncludeTeamEffectivenessMeasurement: false,
+        shouldShowFeedbackAfterCollect: false,
+        isAnonymous: false,
+        activePhase: WorkflowPhase.Collect,
+        teamId: "t1",
+        maxVotesPerUser: 5,
+        teamEffectivenessMeasurementVoteCollection: [],
+        columns: [],
+      },
+      currentUserId: "admin-user",
+      isNewBoardCreation: false,
+      currentTeam,
+      projectTeams: [currentTeam],
+      currentTeamMembers: [],
+      allMembers: [],
+    });
+
+    const memberOptions = result.permissionOptions.filter(option => option.type === "member");
+    expect(memberOptions.some(option => option.id === "admin-user")).toBe(true);
+    expect(memberOptions.some(option => option.id === "owner-1")).toBe(true);
+  });
 });
 
 describe("FeedbackBoardContainer integration", () => {

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -961,6 +961,34 @@ describe("FeedbackBoardContainer integration", () => {
     expect(screen.queryByText("We are unable to retrieve the list of teams for this project. Try reloading the page.")).not.toBeInTheDocument();
   });
 
+  it("keeps the active URL team visible in the selector when the user is not a member", async () => {
+    const otherTeam = { ...mockTeam, id: "t2", name: "Alternate" };
+    const otherTeamBoard = { ...mockBoard, teamId: "t2" };
+
+    props = { isHostedAzureDevOps: true, projectId: "1" };
+    mocked(getService).mockResolvedValue({ getHash: jest.fn().mockResolvedValue("#teamId=t2&boardId=b1&phase=Collect"), setHash: jest.fn() } as any);
+    mocked(azureDevOpsCoreService.getAllTeams).mockResolvedValue([mockTeam as WebApiTeam]);
+    mocked(azureDevOpsCoreService.getDefaultTeam).mockResolvedValue(mockTeam as WebApiTeam);
+    mocked(azureDevOpsCoreService.getTeam).mockResolvedValue(otherTeam as WebApiTeam);
+    mocked(azureDevOpsCoreService.getMembers).mockResolvedValue([]);
+    mocked(userDataService.getMostRecentVisit).mockResolvedValue(null);
+    mocked(userDataService.addVisit).mockResolvedValue(undefined);
+    mocked(BoardDataService.getBoardsForTeam).mockResolvedValue([otherTeamBoard]);
+    mocked(itemDataService.getBoardItem).mockResolvedValue(otherTeamBoard);
+    mocked(itemDataService.getFeedbackItemsForBoard).mockResolvedValue([]);
+    mocked(workItemService.getWorkItemTypesForCurrentProject).mockResolvedValue([]);
+    mocked(workItemService.getHiddenWorkItemTypes).mockResolvedValue([]);
+
+    render(<FeedbackBoardContainer {...props} />);
+
+    expect(await screen.findByRole("heading", { name: "Retrospectives" })).toBeInTheDocument();
+
+    const teamSelector = screen.getByRole("combobox", { name: "Team" }) as HTMLSelectElement;
+    expect(teamSelector.value).toBe("t2");
+    expect(screen.getByRole("option", { name: "Alternate" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Team 1" })).toBeInTheDocument();
+  });
+
   it("loads a board from the URL team when browser local-network restrictions block team REST lookups", async () => {
     mocked(getService).mockResolvedValue({ getHash: jest.fn().mockResolvedValue("#teamId=t1&boardId=b1&phase=Collect"), setHash: jest.fn() } as any);
     mocked(azureDevOpsCoreService.getAllTeams).mockRejectedValue(new Error("Permission was denied for this request to access the local address space"));

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -466,6 +466,55 @@ describe("buildPermissionOptions", () => {
     expect(result.hasReachedUserLimit).toBe(true);
   });
 
+  it("does not flag user limit when only group identities exceed additional candidate count", () => {
+    const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
+    const boardOwner = { id: "user-1", displayName: "User 1", uniqueName: "user1@example.com" } as IdentityRef;
+
+    const currentTeamMembers: TeamMember[] = Array.from({ length: 7 }, (_, index) => ({
+      identity: {
+        id: `user-${index + 1}`,
+        displayName: `User ${index + 1}`,
+        uniqueName: `user${index + 1}@example.com`,
+      } as IdentityRef,
+    })) as TeamMember[];
+
+    const additionalGroupMembers: TeamMember[] = Array.from({ length: 150 }, (_, index) => ({
+      identity: {
+        id: `group-${index + 1}`,
+        displayName: `[Project]\\Team ${index + 1}`,
+        uniqueName: `[Project]\\Team ${index + 1}`,
+      } as IdentityRef,
+    })) as TeamMember[];
+
+    const result = buildPermissionOptions({
+      board: {
+        id: "b1",
+        title: "Board 1",
+        createdDate: new Date(),
+        createdBy: boardOwner,
+        permissions: { Teams: [], Members: [] },
+        boardVoteCollection: {},
+        isIncludeTeamEffectivenessMeasurement: false,
+        shouldShowFeedbackAfterCollect: false,
+        isAnonymous: false,
+        activePhase: WorkflowPhase.Collect,
+        teamId: "t1",
+        maxVotesPerUser: 5,
+        teamEffectivenessMeasurementVoteCollection: [],
+        columns: [],
+      },
+      currentUserId: boardOwner.id,
+      isNewBoardCreation: false,
+      currentTeam,
+      projectTeams: Array.from({ length: 101 }, (_, index) => ({ id: `team-${index + 1}`, name: `Team ${index + 1}`, projectName: "Project" } as WebApiTeam)),
+      currentTeamMembers,
+      allMembers: [...currentTeamMembers, ...additionalGroupMembers],
+    });
+
+    expect(result.hasReachedTeamLimit).toBe(true);
+    expect(result.hasReachedUserLimit).toBe(false);
+  });
+
   it("includes the current user when they are not the owner and not a team member", () => {
     const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
     const boardOwner = { id: "owner-1", displayName: "Owner User", uniqueName: "owner@example.com" } as IdentityRef;

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -370,6 +370,100 @@ describe("buildPermissionOptions", () => {
     expect(result.permissionOptions.some(option => option.id === currentTeam.id && option.type === "team")).toBe(true);
     expect(result.permissionOptions.some(option => option.id === currentUserIdentity.id && option.type === "member")).toBe(true);
   });
+
+  it("does not let group identities consume user cap slots", () => {
+    const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
+    const currentUserIdentity = mockUserIdentity as unknown as IdentityRef;
+
+    const allMembers: TeamMember[] = [
+      { identity: { id: "group-1", displayName: "[Project]\\Contributors", uniqueName: "[Project]\\Contributors" } as IdentityRef } as TeamMember,
+      { identity: { id: "user-1", displayName: "User 1", uniqueName: "user1@example.com" } as IdentityRef } as TeamMember,
+      { identity: { id: "user-2", displayName: "User 2", uniqueName: "user2@example.com" } as IdentityRef } as TeamMember,
+      { identity: { id: "user-3", displayName: "User 3", uniqueName: "user3@example.com" } as IdentityRef } as TeamMember,
+      { identity: { id: "user-4", displayName: "User 4", uniqueName: "user4@example.com" } as IdentityRef } as TeamMember,
+      { identity: { id: "user-5", displayName: "User 5", uniqueName: "user5@example.com" } as IdentityRef } as TeamMember,
+      { identity: { id: "user-6", displayName: "User 6", uniqueName: "user6@example.com" } as IdentityRef } as TeamMember,
+    ];
+
+    const result = buildPermissionOptions({
+      board: {
+        id: "b1",
+        title: "Board 1",
+        createdDate: new Date(),
+        createdBy: currentUserIdentity,
+        permissions: { Teams: [], Members: [] },
+        boardVoteCollection: {},
+        isIncludeTeamEffectivenessMeasurement: false,
+        shouldShowFeedbackAfterCollect: false,
+        isAnonymous: false,
+        activePhase: WorkflowPhase.Collect,
+        teamId: "t1",
+        maxVotesPerUser: 5,
+        teamEffectivenessMeasurementVoteCollection: [],
+        columns: [],
+      },
+      currentUserId: currentUserIdentity.id,
+      isNewBoardCreation: true,
+      currentTeam,
+      projectTeams: [currentTeam],
+      allMembers,
+    });
+
+    const memberOptions = result.permissionOptions.filter(option => option.type === "member");
+    expect(memberOptions).toHaveLength(6);
+    expect(memberOptions.some(option => option.id === "group-1")).toBe(false);
+    expect(result.hasReachedUserLimit).toBe(true);
+  });
+
+  it("includes all current-team users before applying additional user cap", () => {
+    const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
+    const boardOwner = { id: "user-1", displayName: "User 1", uniqueName: "user1@example.com" } as IdentityRef;
+
+    const currentTeamMembers: TeamMember[] = Array.from({ length: 7 }, (_, index) => ({
+      identity: {
+        id: `user-${index + 1}`,
+        displayName: `User ${index + 1}`,
+        uniqueName: `user${index + 1}@example.com`,
+      } as IdentityRef,
+    })) as TeamMember[];
+
+    const allMembers: TeamMember[] = [
+      ...currentTeamMembers,
+      { identity: { id: "other-1", displayName: "Other 1", uniqueName: "other1@example.com" } as IdentityRef } as TeamMember,
+      { identity: { id: "other-2", displayName: "Other 2", uniqueName: "other2@example.com" } as IdentityRef } as TeamMember,
+    ];
+
+    const result = buildPermissionOptions({
+      board: {
+        id: "b1",
+        title: "Board 1",
+        createdDate: new Date(),
+        createdBy: boardOwner,
+        permissions: { Teams: [], Members: [] },
+        boardVoteCollection: {},
+        isIncludeTeamEffectivenessMeasurement: false,
+        shouldShowFeedbackAfterCollect: false,
+        isAnonymous: false,
+        activePhase: WorkflowPhase.Collect,
+        teamId: "t1",
+        maxVotesPerUser: 5,
+        teamEffectivenessMeasurementVoteCollection: [],
+        columns: [],
+      },
+      currentUserId: boardOwner.id,
+      isNewBoardCreation: false,
+      currentTeam,
+      projectTeams: [currentTeam],
+      currentTeamMembers,
+      allMembers,
+    });
+
+    const memberOptions = result.permissionOptions.filter(option => option.type === "member");
+    expect(memberOptions).toHaveLength(7);
+    expect(memberOptions.some(option => option.id === "other-1")).toBe(false);
+    expect(memberOptions.some(option => option.id === "other-2")).toBe(false);
+    expect(result.hasReachedUserLimit).toBe(true);
+  });
 });
 
 describe("FeedbackBoardContainer integration", () => {

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -5,7 +5,7 @@ import "@testing-library/jest-dom";
 import { mocked } from "jest-mock";
 import { TeamMember } from "azure-devops-extension-api/WebApi";
 import type { WebApiTeam } from "azure-devops-extension-api/Core";
-import { FeedbackBoardContainer, deduplicateTeamMembers } from "../feedbackBoardContainer";
+import { FeedbackBoardContainer, buildPermissionOptions, deduplicateTeamMembers } from "../feedbackBoardContainer";
 import { IFeedbackBoardDocument, IFeedbackBoardDocumentPermissions, IFeedbackItemDocument } from "../../interfaces/feedback";
 import { WorkflowPhase } from "../../interfaces/workItem";
 import { IdentityRef } from "azure-devops-extension-api/WebApi";
@@ -335,6 +335,40 @@ describe("deduplicateTeamMembers", () => {
   it("handles empty array", () => {
     const deduped = deduplicateTeamMembers([]);
     expect(deduped).toHaveLength(0);
+  });
+});
+
+describe("buildPermissionOptions", () => {
+  it("includes the current team and board owner", () => {
+    const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
+    const currentUserIdentity = mockUserIdentity as unknown as IdentityRef;
+
+    const result = buildPermissionOptions({
+      board: {
+        id: "b1",
+        title: "Board 1",
+        createdDate: new Date(),
+        createdBy: currentUserIdentity,
+        permissions: { Teams: [], Members: [] },
+        boardVoteCollection: {},
+        isIncludeTeamEffectivenessMeasurement: false,
+        shouldShowFeedbackAfterCollect: false,
+        isAnonymous: false,
+        activePhase: WorkflowPhase.Collect,
+        teamId: "t1",
+        maxVotesPerUser: 5,
+        teamEffectivenessMeasurementVoteCollection: [],
+        columns: [],
+      },
+      currentUserId: currentUserIdentity.id,
+      isNewBoardCreation: true,
+      currentTeam,
+      projectTeams: [currentTeam],
+      allMembers: [],
+    });
+
+    expect(result.permissionOptions.some(option => option.id === currentTeam.id && option.type === "team")).toBe(true);
+    expect(result.permissionOptions.some(option => option.id === currentUserIdentity.id && option.type === "member")).toBe(true);
   });
 });
 

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -377,7 +377,7 @@ describe("buildPermissionOptions", () => {
 
     const allMembers: TeamMember[] = [
       { identity: { id: "group-1", displayName: "[Project]\\Contributors", uniqueName: "[Project]\\Contributors" } as IdentityRef } as TeamMember,
-      ...Array.from({ length: 500 }, (_, index) => ({
+      ...Array.from({ length: 200 }, (_, index) => ({
         identity: {
           id: `user-${index + 1}`,
           displayName: `User ${index + 1}`,
@@ -411,7 +411,7 @@ describe("buildPermissionOptions", () => {
     });
 
     const memberOptions = result.permissionOptions.filter(option => option.type === "member");
-    expect(memberOptions).toHaveLength(501);
+    expect(memberOptions).toHaveLength(201);
     expect(memberOptions.some(option => option.id === "group-1")).toBe(false);
     expect(result.hasReachedUserLimit).toBe(false);
   });
@@ -684,7 +684,7 @@ describe("buildPermissionOptions", () => {
     const currentTeam = { id: "current-team", name: "Current Team", projectName: "Project" } as WebApiTeam;
     const boardOwner = { id: "owner-1", displayName: "Owner User", uniqueName: "owner@example.com" } as IdentityRef;
 
-    const currentTeamMembers: TeamMember[] = Array.from({ length: 500 }, (_, index) => ({
+    const currentTeamMembers: TeamMember[] = Array.from({ length: 200 }, (_, index) => ({
       identity: {
         id: `member-${index + 1}`,
         displayName: `Member ${index + 1}`,

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -178,7 +178,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("All current team users are shown. Additional users from other teams are limited to 10.")).toBeInTheDocument();
+      expect(getByText("Only the first 500 users are shown.")).toBeInTheDocument();
     });
 
     it("should show a team limit banner when the team cap is reached", () => {
@@ -188,7 +188,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Only the first 10 teams are shown.")).toBeInTheDocument();
+      expect(getByText("Only the first 100 teams are shown.")).toBeInTheDocument();
     });
 
     it("should show a combined limit banner when both caps are reached", () => {
@@ -198,9 +198,9 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText, queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("All current team users are shown. Additional users and teams are limited to 10.")).toBeInTheDocument();
-      expect(queryByText("All current team users are shown. Additional users from other teams are limited to 10.")).not.toBeInTheDocument();
-      expect(queryByText("Only the first 10 teams are shown.")).not.toBeInTheDocument();
+      expect(getByText("Only the first 500 users and 100 teams are shown.")).toBeInTheDocument();
+      expect(queryByText("Only the first 500 users are shown.")).not.toBeInTheDocument();
+      expect(queryByText("Only the first 100 teams are shown.")).not.toBeInTheDocument();
     });
   });
 

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -190,6 +190,18 @@ describe("Board Metadata Form Permissions", () => {
 
       expect(getByText("Only the first 5 teams are shown.")).toBeInTheDocument();
     });
+
+    it("should show a combined limit banner when both caps are reached", () => {
+      const props = makeProps({
+        permissionLimitReached: { users: true, teams: true },
+      });
+
+      const { getByText, queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
+
+      expect(getByText("Only the first 5 users and 5 teams are shown.")).toBeInTheDocument();
+      expect(queryByText("Only the first 5 users are shown.")).not.toBeInTheDocument();
+      expect(queryByText("Only the first 5 teams are shown.")).not.toBeInTheDocument();
+    });
   });
 
   describe("Permission Table", () => {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -198,7 +198,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText, queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Reached 500 user or 100 team retrieval limit.")).toBeInTheDocument();
+      expect(getByText("Reached 500 user and 100 team retrieval limit.")).toBeInTheDocument();
       expect(queryByText("Reached 500 user retrieval limit.")).not.toBeInTheDocument();
       expect(queryByText("Reached 100 team retrieval limit.")).not.toBeInTheDocument();
     });

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -178,7 +178,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("All current team users are shown. Additional users from other teams are limited to 5.")).toBeInTheDocument();
+      expect(getByText("All current team users are shown. Additional users from other teams are limited to 10.")).toBeInTheDocument();
     });
 
     it("should show a team limit banner when the team cap is reached", () => {
@@ -188,7 +188,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Only the first 5 teams are shown.")).toBeInTheDocument();
+      expect(getByText("Only the first 10 teams are shown.")).toBeInTheDocument();
     });
 
     it("should show a combined limit banner when both caps are reached", () => {
@@ -198,9 +198,9 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText, queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("All current team users are shown. Additional users and teams are limited to 5.")).toBeInTheDocument();
-      expect(queryByText("All current team users are shown. Additional users from other teams are limited to 5.")).not.toBeInTheDocument();
-      expect(queryByText("Only the first 5 teams are shown.")).not.toBeInTheDocument();
+      expect(getByText("All current team users are shown. Additional users and teams are limited to 10.")).toBeInTheDocument();
+      expect(queryByText("All current team users are shown. Additional users from other teams are limited to 10.")).not.toBeInTheDocument();
+      expect(queryByText("Only the first 10 teams are shown.")).not.toBeInTheDocument();
     });
   });
 

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -178,7 +178,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Only the first 500 users are shown.")).toBeInTheDocument();
+      expect(getByText("Additional results are capped at 500 users.")).toBeInTheDocument();
     });
 
     it("should show a team limit banner when the team cap is reached", () => {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -178,7 +178,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Additional results are capped at 500 users.")).toBeInTheDocument();
+      expect(getByText("Showing up to 500 additional users.")).toBeInTheDocument();
     });
 
     it("should show a team limit banner when the team cap is reached", () => {
@@ -188,7 +188,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Additional results are capped at 100 teams.")).toBeInTheDocument();
+      expect(getByText("Showing up to 100 additional teams.")).toBeInTheDocument();
     });
 
     it("should show a combined limit banner when both caps are reached", () => {
@@ -198,9 +198,9 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText, queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Additional results are capped at 500 users and 100 teams.")).toBeInTheDocument();
-      expect(queryByText("Additional results are capped at 500 users.")).not.toBeInTheDocument();
-      expect(queryByText("Additional results are capped at 100 teams.")).not.toBeInTheDocument();
+      expect(getByText("Showing up to 500 additional users and 100 additional teams.")).toBeInTheDocument();
+      expect(queryByText("Showing up to 500 additional users.")).not.toBeInTheDocument();
+      expect(queryByText("Showing up to 100 additional teams.")).not.toBeInTheDocument();
     });
   });
 

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -178,7 +178,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Additional results are capped at 500 users.")).toBeInTheDocument();
+      expect(getByText("Reached 500 user retrieval limit.")).toBeInTheDocument();
     });
 
     it("should show a team limit banner when the team cap is reached", () => {
@@ -188,7 +188,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Only the first 100 teams are shown.")).toBeInTheDocument();
+      expect(getByText("Reached 100 team retrieval limit.")).toBeInTheDocument();
     });
 
     it("should show a combined limit banner when both caps are reached", () => {
@@ -198,9 +198,9 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText, queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Only the first 500 users and 100 teams are shown.")).toBeInTheDocument();
-      expect(queryByText("Only the first 500 users are shown.")).not.toBeInTheDocument();
-      expect(queryByText("Only the first 100 teams are shown.")).not.toBeInTheDocument();
+      expect(getByText("Reached 500 user or 100 team retrieval limit.")).toBeInTheDocument();
+      expect(queryByText("Reached 500 user retrieval limit.")).not.toBeInTheDocument();
+      expect(queryByText("Reached 100 team retrieval limit.")).not.toBeInTheDocument();
     });
   });
 

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -178,7 +178,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Reached 500 user retrieval limit.")).toBeInTheDocument();
+      expect(getByText("Additional results are capped at 500 users.")).toBeInTheDocument();
     });
 
     it("should show a team limit banner when the team cap is reached", () => {
@@ -188,7 +188,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Reached 100 team retrieval limit.")).toBeInTheDocument();
+      expect(getByText("Additional results are capped at 100 teams.")).toBeInTheDocument();
     });
 
     it("should show a combined limit banner when both caps are reached", () => {
@@ -198,9 +198,9 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText, queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Reached 500 user and 100 team retrieval limit.")).toBeInTheDocument();
-      expect(queryByText("Reached 500 user retrieval limit.")).not.toBeInTheDocument();
-      expect(queryByText("Reached 100 team retrieval limit.")).not.toBeInTheDocument();
+      expect(getByText("Additional results are capped at 500 users and 100 teams.")).toBeInTheDocument();
+      expect(queryByText("Additional results are capped at 500 users.")).not.toBeInTheDocument();
+      expect(queryByText("Additional results are capped at 100 teams.")).not.toBeInTheDocument();
     });
   });
 

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -170,6 +170,26 @@ describe("Board Metadata Form Permissions", () => {
       const { queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
       expect(queryByText("This board is visible to every member in the project.")).not.toBeInTheDocument();
     });
+
+    it("should show a user limit banner when the user cap is reached", () => {
+      const props = makeProps({
+        permissionLimitReached: { users: true, teams: false },
+      });
+
+      const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
+
+      expect(getByText("Only the first 500 users are shown.")).toBeInTheDocument();
+    });
+
+    it("should show a team limit banner when the team cap is reached", () => {
+      const props = makeProps({
+        permissionLimitReached: { users: false, teams: true },
+      });
+
+      const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
+
+      expect(getByText("Only the first 100 teams are shown.")).toBeInTheDocument();
+    });
   });
 
   describe("Permission Table", () => {

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -178,7 +178,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Only the first 5 users are shown.")).toBeInTheDocument();
+      expect(getByText("All current team users are shown. Additional users from other teams are limited to 5.")).toBeInTheDocument();
     });
 
     it("should show a team limit banner when the team cap is reached", () => {
@@ -198,8 +198,8 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText, queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Only the first 5 users and 5 teams are shown.")).toBeInTheDocument();
-      expect(queryByText("Only the first 5 users are shown.")).not.toBeInTheDocument();
+      expect(getByText("All current team users are shown. Additional users and teams are limited to 5.")).toBeInTheDocument();
+      expect(queryByText("All current team users are shown. Additional users from other teams are limited to 5.")).not.toBeInTheDocument();
       expect(queryByText("Only the first 5 teams are shown.")).not.toBeInTheDocument();
     });
   });

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -178,7 +178,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Only the first 500 users are shown.")).toBeInTheDocument();
+      expect(getByText("Only the first 5 users are shown.")).toBeInTheDocument();
     });
 
     it("should show a team limit banner when the team cap is reached", () => {
@@ -188,7 +188,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Only the first 100 teams are shown.")).toBeInTheDocument();
+      expect(getByText("Only the first 5 teams are shown.")).toBeInTheDocument();
     });
   });
 

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -178,7 +178,7 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Showing up to 500 additional users.")).toBeInTheDocument();
+      expect(getByText("Showing up to 200 additional users.")).toBeInTheDocument();
     });
 
     it("should show a team limit banner when the team cap is reached", () => {
@@ -198,8 +198,8 @@ describe("Board Metadata Form Permissions", () => {
 
       const { getByText, queryByText } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
 
-      expect(getByText("Showing up to 500 additional users and 100 additional teams.")).toBeInTheDocument();
-      expect(queryByText("Showing up to 500 additional users.")).not.toBeInTheDocument();
+      expect(getByText("Showing up to 200 additional users and 100 additional teams.")).toBeInTheDocument();
+      expect(queryByText("Showing up to 200 additional users.")).not.toBeInTheDocument();
       expect(queryByText("Showing up to 100 additional teams.")).not.toBeInTheDocument();
     });
   });

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -96,6 +96,7 @@ export interface FeedbackBoardContainerState {
   actionItemIds: number[];
   allMembers: TeamMember[];
   currentTeamMembers: TeamMember[];
+  hasReachedAdditionalMemberLoadLimit: boolean;
   castedVoteCount: number;
   currentVoteCount: string;
   teamVoteCapacity: number;
@@ -375,6 +376,7 @@ const initialState: FeedbackBoardContainerState = {
   actionItemIds: [],
   allMembers: [],
   currentTeamMembers: [],
+  hasReachedAdditionalMemberLoadLimit: false,
   castedVoteCount: 0,
   currentVoteCount: "0",
   teamVoteCapacity: 0,
@@ -1433,8 +1435,9 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     }
   };
 
-  const loadMembersForTeams = async (teams: WebApiTeam[]): Promise<TeamMember[]> => {
+  const loadMembersForTeams = async (teams: WebApiTeam[]): Promise<{ members: TeamMember[]; didHitLimit: boolean }> => {
     const accumulated: TeamMember[] = [];
+    let didHitLimit = false;
 
     for (let i = 0; i < teams.length; i += MEMBER_LOAD_CONCURRENCY) {
       const batch = teams.slice(i, i + MEMBER_LOAD_CONCURRENCY);
@@ -1443,11 +1446,12 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
 
       const uniqueNonGroupCount = deduplicateTeamMembers(accumulated).filter(member => !isGroupIdentity(member.identity)).length;
       if (uniqueNonGroupCount >= PERMISSION_USER_LIMIT) {
+        didHitLimit = true;
         break;
       }
     }
 
-    return deduplicateTeamMembers(accumulated);
+    return { members: deduplicateTeamMembers(accumulated), didHitLimit };
   };
 
   const loadMembersForTeam = async (team: WebApiTeam | null | undefined): Promise<TeamMember[]> => {
@@ -1478,11 +1482,12 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     }));
 
     Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(defaultTeam)])
-      .then(([additionalMembers, currentTeamMembers]) =>
+      .then(([additionalMembersResult, currentTeamMembers]) =>
         setContainerState(previousState => ({
           ...previousState,
-          allMembers: deduplicateTeamMembers([...currentTeamMembers, ...additionalMembers]),
+          allMembers: deduplicateTeamMembers([...currentTeamMembers, ...additionalMembersResult.members]),
           currentTeamMembers,
+          hasReachedAdditionalMemberLoadLimit: additionalMembersResult.didHitLimit,
         })),
       )
       .catch(error => appInsights.trackException(error, { action: "initializeProjectTeamMembers" }));
@@ -1492,12 +1497,13 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     const allTeams = sortTeamsByName(await azureDevOpsCoreService.getAllTeams(projectId, false));
     const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams]);
     const memberTeams = projectTeams.filter(team => team.id !== state.currentTeam?.id);
-    const [additionalMembers, currentTeamMembers] = await Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(state.currentTeam)]);
+    const [additionalMembersResult, currentTeamMembers] = await Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(state.currentTeam)]);
 
     setContainerState(previousState => ({
       ...previousState,
-      allMembers: deduplicateTeamMembers([...currentTeamMembers, ...additionalMembers]),
+      allMembers: deduplicateTeamMembers([...currentTeamMembers, ...additionalMembersResult.members]),
       currentTeamMembers,
+      hasReachedAdditionalMemberLoadLimit: additionalMembersResult.didHitLimit,
       projectTeams,
       filteredProjectTeams: projectTeams,
       isAllTeamsLoaded: true,
@@ -2211,7 +2217,10 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
           placeholderText={placeholderText}
           availablePermissionOptions={permissionOptionsBuildResult.permissionOptions}
           currentUserId={state.currentUserId}
-          permissionLimitReached={{ users: permissionOptionsBuildResult.hasReachedUserLimit, teams: permissionOptionsBuildResult.hasReachedTeamLimit }}
+          permissionLimitReached={{
+            users: permissionOptionsBuildResult.hasReachedUserLimit || state.hasReachedAdditionalMemberLoadLimit,
+            teams: permissionOptionsBuildResult.hasReachedTeamLimit,
+          }}
           onFormSubmit={onSubmit}
           onFormCancel={onCancel}
         />

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -128,8 +128,8 @@ export function deduplicateTeamMembers(allTeamMembers: TeamMember[]): TeamMember
   });
 }
 
-const PERMISSION_TEAM_LIMIT = 100;
-const PERMISSION_USER_LIMIT = 500;
+const PERMISSION_TEAM_LIMIT = 5;
+const PERMISSION_USER_LIMIT = 5;
 
 function uniqueItemsById<T extends { id?: string }>(items: Array<T | null | undefined>): T[] {
   const seenIds = new Set<string>();
@@ -1425,7 +1425,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
 
   const loadAllProjectTeams = async (): Promise<void> => {
     const allTeams = sortTeamsByName(await azureDevOpsCoreService.getAllTeams(projectId, false));
-    const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams, ...(state.userTeams ?? [])]);
+    const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams]).slice(0, PERMISSION_TEAM_LIMIT);
     const memberTeams = uniqueItemsById([state.currentTeam, ...projectTeams]);
     const [allMembers, currentTeamMembers] = await Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(state.currentTeam)]);
 
@@ -2121,9 +2121,9 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
       currentUserId: state.currentUserId,
       isNewBoardCreation,
       currentTeam: state.currentTeam,
-      projectTeams: state.projectTeams,
+      projectTeams: showAllTeams ? state.projectTeams : state.userTeams,
       currentTeamMembers: state.currentTeamMembers,
-      allMembers: state.allMembers,
+      allMembers: showAllTeams ? state.allMembers : state.currentTeamMembers,
     });
 
     return (

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -219,8 +219,6 @@ export function buildPermissionOptions(args: {
   currentTeamMembers?: TeamMember[];
   allMembers: TeamMember[];
 }): PermissionOptionsBuildResult {
-  const ownerIdentity = getOwnerIdentity(args.board, args.isNewBoardCreation, args.currentUserId);
-  const currentUserIdentity = getCurrentUserPermissionIdentity(args.currentUserId);
   const permissionTeams = args.board?.permissions?.Teams ?? [];
   const permissionMembers = args.board?.permissions?.Members ?? [];
 
@@ -236,21 +234,31 @@ export function buildPermissionOptions(args: {
     }
   }
 
-  const teamOptions: FeedbackBoardPermissionOption[] = [];
-  const addTeamOption = (team: WebApiTeam | null | undefined): void => {
-    if (!team?.id || teamOptions.some(option => option.id === team.id)) {
+  const ownerIdentity = getOwnerIdentity(args.board, args.isNewBoardCreation, args.currentUserId);
+  const currentUserIdentity = getCurrentUserPermissionIdentity(args.currentUserId);
+  const resolvedOwner = ownerIdentity?.id ? memberLookup.get(ownerIdentity.id) : undefined;
+  const resolvedCurrentUser = currentUserIdentity?.id ? memberLookup.get(currentUserIdentity.id) : undefined;
+
+  const requiredTeamOptions: FeedbackBoardPermissionOption[] = [];
+  const additionalTeamOptions: FeedbackBoardPermissionOption[] = [];
+  const teamOptionIds = new Set<string>();
+  const addTeamOption = (team: WebApiTeam | null | undefined, isRequired: boolean): void => {
+    if (!team?.id || teamOptionIds.has(team.id)) {
       return;
     }
 
-    teamOptions.push(toTeamPermissionOption(team));
+    teamOptionIds.add(team.id);
+
+    const targetCollection = isRequired ? requiredTeamOptions : additionalTeamOptions;
+    targetCollection.push(toTeamPermissionOption(team));
   };
 
-  addTeamOption(args.currentTeam);
+  addTeamOption(args.currentTeam, true);
   for (const permissionTeamId of permissionTeams) {
-    addTeamOption(teamLookup.get(permissionTeamId) ?? ({ id: permissionTeamId, name: permissionTeamId, projectName: permissionTeamId } as WebApiTeam));
+    addTeamOption(teamLookup.get(permissionTeamId) ?? ({ id: permissionTeamId, name: permissionTeamId, projectName: permissionTeamId } as WebApiTeam), true);
   }
   for (const projectTeam of args.projectTeams) {
-    addTeamOption(projectTeam);
+    addTeamOption(projectTeam, false);
   }
 
   const memberOptions: FeedbackBoardPermissionOption[] = [];
@@ -281,8 +289,8 @@ export function buildPermissionOptions(args: {
     return true;
   };
 
-  addMemberOption(currentUserIdentity, args.currentUserIsTeamAdmin);
-  addMemberOption(ownerIdentity);
+  addMemberOption(resolvedCurrentUser?.identity ?? currentUserIdentity, args.currentUserIsTeamAdmin ?? resolvedCurrentUser?.isTeamAdmin);
+  addMemberOption(resolvedOwner?.identity ?? ownerIdentity, resolvedOwner?.isTeamAdmin);
   for (const permissionMemberId of permissionMembers) {
     const resolvedMember = memberLookup.get(permissionMemberId);
     addMemberOption(resolvedMember?.identity ?? ({ id: permissionMemberId, displayName: permissionMemberId, uniqueName: permissionMemberId } as TeamMember["identity"]), resolvedMember?.isTeamAdmin);
@@ -297,9 +305,10 @@ export function buildPermissionOptions(args: {
   }
 
   const additionalMemberAllowance = Math.max(PERMISSION_USER_LIMIT - currentTeamMemberIds.size, 0);
+  const requiredMemberIds = new Set(memberOptions.map(option => option.id));
   const additionalMemberCandidates = deduplicateTeamMembers(args.allMembers).filter(member => {
     const memberId = member?.identity?.id;
-    return !!memberId && !currentTeamMemberIds.has(memberId) && !isGroupIdentity(member.identity);
+    return !!memberId && !currentTeamMemberIds.has(memberId) && !requiredMemberIds.has(memberId) && !isGroupIdentity(member.identity);
   });
 
   let additionalMemberCount = 0;
@@ -315,9 +324,12 @@ export function buildPermissionOptions(args: {
     }
   }
 
-  const hasReachedTeamLimit = teamOptions.length > PERMISSION_TEAM_LIMIT;
+  const additionalTeamAllowance = Math.max(PERMISSION_TEAM_LIMIT - requiredTeamOptions.length, 0);
+  const visibleAdditionalTeamOptions = additionalTeamOptions.slice(0, additionalTeamAllowance);
+  const hasReachedTeamLimit = additionalTeamOptions.length > visibleAdditionalTeamOptions.length;
+
   return {
-    permissionOptions: [...teamOptions.slice(0, PERMISSION_TEAM_LIMIT), ...memberOptions],
+    permissionOptions: [...requiredTeamOptions, ...visibleAdditionalTeamOptions, ...memberOptions],
     hasReachedTeamLimit,
     hasReachedUserLimit,
   };
@@ -1454,7 +1466,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
 
   const initializeProjectTeams = (defaultTeam: WebApiTeam, userTeams: WebApiTeam[]) => {
     const projectTeams = uniqueItemsById([defaultTeam, ...(userTeams ?? [])]);
-    const memberTeams = uniqueItemsById([defaultTeam, ...projectTeams]);
+    const memberTeams = projectTeams.filter(team => team.id !== defaultTeam.id);
 
     setContainerState(previousState => ({
       ...previousState,
@@ -1464,21 +1476,25 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     }));
 
     Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(defaultTeam)])
-      .then(([allMembers, currentTeamMembers]) => setContainerState(previousState => ({ ...previousState, allMembers, currentTeamMembers })))
+      .then(([additionalMembers, currentTeamMembers]) =>
+        setContainerState(previousState => ({
+          ...previousState,
+          allMembers: deduplicateTeamMembers([...currentTeamMembers, ...additionalMembers]),
+          currentTeamMembers,
+        })),
+      )
       .catch(error => appInsights.trackException(error, { action: "initializeProjectTeamMembers" }));
   };
 
   const loadAllProjectTeams = async (): Promise<void> => {
     const allTeams = sortTeamsByName(await azureDevOpsCoreService.getAllTeams(projectId, false));
     const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams]);
-    const memberTeams = uniqueItemsById([state.currentTeam, ...projectTeams]);
-    const otherTeams = memberTeams.filter(t => t.id !== state.currentTeam?.id);
-    const [otherMembers, currentTeamMembers] = await Promise.all([loadMembersForTeams(otherTeams), loadMembersForTeam(state.currentTeam)]);
-    const allMembers = deduplicateTeamMembers([...currentTeamMembers, ...otherMembers]);
+    const memberTeams = projectTeams.filter(team => team.id !== state.currentTeam?.id);
+    const [additionalMembers, currentTeamMembers] = await Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(state.currentTeam)]);
 
     setContainerState(previousState => ({
       ...previousState,
-      allMembers,
+      allMembers: deduplicateTeamMembers([...currentTeamMembers, ...additionalMembers]),
       currentTeamMembers,
       projectTeams,
       filteredProjectTeams: projectTeams,
@@ -2171,7 +2187,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
       currentTeam: state.currentTeam,
       projectTeams: showAllTeams ? state.projectTeams : state.userTeams,
       currentTeamMembers: state.currentTeamMembers,
-      allMembers: showAllTeams ? state.allMembers : state.currentTeamMembers,
+      allMembers: state.allMembers,
     });
 
     return (

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -185,6 +185,23 @@ function getOwnerIdentity(board: IFeedbackBoardDocument | null | undefined, isNe
   return board?.createdBy ?? null;
 }
 
+function getCurrentUserPermissionIdentity(currentUserId: string): TeamMember["identity"] | null {
+  if (!currentUserId) {
+    return null;
+  }
+
+  const currentUser = getUserIdentity();
+  if (currentUser?.id === currentUserId) {
+    return currentUser;
+  }
+
+  return {
+    id: currentUserId,
+    displayName: currentUserId,
+    uniqueName: currentUserId,
+  } as TeamMember["identity"];
+}
+
 export interface PermissionOptionsBuildResult {
   permissionOptions: FeedbackBoardPermissionOption[];
   hasReachedTeamLimit: boolean;
@@ -201,6 +218,7 @@ export function buildPermissionOptions(args: {
   allMembers: TeamMember[];
 }): PermissionOptionsBuildResult {
   const ownerIdentity = getOwnerIdentity(args.board, args.isNewBoardCreation, args.currentUserId);
+  const currentUserIdentity = getCurrentUserPermissionIdentity(args.currentUserId);
   const permissionTeams = args.board?.permissions?.Teams ?? [];
   const permissionMembers = args.board?.permissions?.Members ?? [];
 
@@ -248,6 +266,7 @@ export function buildPermissionOptions(args: {
     return true;
   };
 
+  addMemberOption(currentUserIdentity);
   addMemberOption(ownerIdentity);
   for (const permissionMemberId of permissionMembers) {
     const resolvedMember = memberLookup.get(permissionMemberId);

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -128,8 +128,8 @@ export function deduplicateTeamMembers(allTeamMembers: TeamMember[]): TeamMember
   });
 }
 
-const PERMISSION_TEAM_LIMIT = 5;
-const PERMISSION_USER_LIMIT = 5;
+const PERMISSION_TEAM_LIMIT = 100;
+const PERMISSION_USER_LIMIT = 500;
 
 function uniqueItemsById<T extends { id?: string }>(items: Array<T | null | undefined>): T[] {
   const seenIds = new Set<string>();

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -127,8 +127,8 @@ export function deduplicateTeamMembers(allTeamMembers: TeamMember[]): TeamMember
   });
 }
 
-const PERMISSION_TEAM_LIMIT = 100;
-const PERMISSION_USER_LIMIT = 500;
+const PERMISSION_TEAM_LIMIT = 5;
+const PERMISSION_USER_LIMIT = 5;
 
 function uniqueItemsById<T extends { id?: string }>(items: Array<T | null | undefined>): T[] {
   const seenIds = new Set<string>();

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1460,7 +1460,9 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     const allTeams = sortTeamsByName(await azureDevOpsCoreService.getAllTeams(projectId, false));
     const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams]);
     const memberTeams = uniqueItemsById([state.currentTeam, ...projectTeams]);
-    const [allMembers, currentTeamMembers] = await Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(state.currentTeam)]);
+    const otherTeams = memberTeams.filter(t => t.id !== state.currentTeam?.id);
+    const [otherMembers, currentTeamMembers] = await Promise.all([loadMembersForTeams(otherTeams), loadMembersForTeam(state.currentTeam)]);
+    const allMembers = deduplicateTeamMembers([...currentTeamMembers, ...otherMembers]);
 
     setContainerState(previousState => ({
       ...previousState,

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -128,8 +128,8 @@ export function deduplicateTeamMembers(allTeamMembers: TeamMember[]): TeamMember
   });
 }
 
-const PERMISSION_TEAM_LIMIT = 10;
-const PERMISSION_USER_LIMIT = 10;
+const PERMISSION_TEAM_LIMIT = 100;
+const PERMISSION_USER_LIMIT = 500;
 
 function uniqueItemsById<T extends { id?: string }>(items: Array<T | null | undefined>): T[] {
   const seenIds = new Set<string>();

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -128,8 +128,8 @@ export function deduplicateTeamMembers(allTeamMembers: TeamMember[]): TeamMember
   });
 }
 
-const PERMISSION_TEAM_LIMIT = 5;
-const PERMISSION_USER_LIMIT = 5;
+const PERMISSION_TEAM_LIMIT = 10;
+const PERMISSION_USER_LIMIT = 10;
 
 function uniqueItemsById<T extends { id?: string }>(items: Array<T | null | undefined>): T[] {
   const seenIds = new Set<string>();

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -95,6 +95,7 @@ export interface FeedbackBoardContainerState {
   teamEffectivenessMeasurementAverageVisibilityClassName: string;
   actionItemIds: number[];
   allMembers: TeamMember[];
+  currentTeamMembers: TeamMember[];
   castedVoteCount: number;
   currentVoteCount: string;
   teamVoteCapacity: number;
@@ -166,6 +167,11 @@ function toMemberPermissionOption(member: TeamMember["identity"], isTeamAdmin?: 
   };
 }
 
+function isGroupIdentity(memberIdentity: TeamMember["identity"] | null | undefined): boolean {
+  const identityName = memberIdentity?.displayName || memberIdentity?.uniqueName || "";
+  return /^\[[^\]]+\]\\/.test(identityName);
+}
+
 function getOwnerIdentity(board: IFeedbackBoardDocument | null | undefined, isNewBoardCreation: boolean, currentUserId: string): TeamMember["identity"] | null {
   if (isNewBoardCreation) {
     const currentUser = getUserIdentity();
@@ -191,6 +197,7 @@ export function buildPermissionOptions(args: {
   isNewBoardCreation: boolean;
   currentTeam: WebApiTeam | null | undefined;
   projectTeams: WebApiTeam[];
+  currentTeamMembers?: TeamMember[];
   allMembers: TeamMember[];
 }): PermissionOptionsBuildResult {
   const ownerIdentity = getOwnerIdentity(args.board, args.isNewBoardCreation, args.currentUserId);
@@ -203,7 +210,7 @@ export function buildPermissionOptions(args: {
   }
 
   const memberLookup = new Map<string, TeamMember>();
-  for (const member of args.allMembers) {
+  for (const member of [...(args.currentTeamMembers ?? []), ...args.allMembers]) {
     if (member?.identity?.id) {
       memberLookup.set(member.identity.id, member);
     }
@@ -227,12 +234,18 @@ export function buildPermissionOptions(args: {
   }
 
   const memberOptions: FeedbackBoardPermissionOption[] = [];
-  const addMemberOption = (memberIdentity: TeamMember["identity"] | null | undefined, isTeamAdmin?: boolean): void => {
+  const addMemberOption = (memberIdentity: TeamMember["identity"] | null | undefined, isTeamAdmin?: boolean): boolean => {
     if (!memberIdentity?.id || memberOptions.some(option => option.id === memberIdentity.id)) {
-      return;
+      return false;
+    }
+
+    // Keep group-style identities out of the capped member list so they don't consume user slots.
+    if (isGroupIdentity(memberIdentity)) {
+      return false;
     }
 
     memberOptions.push(toMemberPermissionOption(memberIdentity, isTeamAdmin));
+    return true;
   };
 
   addMemberOption(ownerIdentity);
@@ -240,15 +253,37 @@ export function buildPermissionOptions(args: {
     const resolvedMember = memberLookup.get(permissionMemberId);
     addMemberOption(resolvedMember?.identity ?? ({ id: permissionMemberId, displayName: permissionMemberId, uniqueName: permissionMemberId } as TeamMember["identity"]), resolvedMember?.isTeamAdmin);
   }
-  for (const member of args.allMembers) {
+  const currentTeamMembers = deduplicateTeamMembers(args.currentTeamMembers ?? []);
+  const currentTeamMemberIds = new Set<string>();
+  for (const member of currentTeamMembers) {
+    if (member?.identity?.id && !isGroupIdentity(member.identity)) {
+      currentTeamMemberIds.add(member.identity.id);
+    }
     addMemberOption(member.identity, member.isTeamAdmin);
   }
 
+  const additionalMemberAllowance = Math.max(PERMISSION_USER_LIMIT - currentTeamMemberIds.size, 0);
+  const additionalMemberCandidates = deduplicateTeamMembers(args.allMembers).filter(member => {
+    const memberId = member?.identity?.id;
+    return !!memberId && !currentTeamMemberIds.has(memberId);
+  });
+
+  let additionalMemberCount = 0;
+  for (const member of additionalMemberCandidates) {
+    if (additionalMemberCount >= additionalMemberAllowance) {
+      break;
+    }
+
+    if (addMemberOption(member.identity, member.isTeamAdmin)) {
+      additionalMemberCount += 1;
+    }
+  }
+
   const hasReachedTeamLimit = teamOptions.length > PERMISSION_TEAM_LIMIT;
-  const hasReachedUserLimit = memberOptions.length > PERMISSION_USER_LIMIT;
+  const hasReachedUserLimit = additionalMemberCandidates.length > additionalMemberCount;
 
   return {
-    permissionOptions: [...teamOptions.slice(0, PERMISSION_TEAM_LIMIT), ...memberOptions.slice(0, PERMISSION_USER_LIMIT)],
+    permissionOptions: [...teamOptions.slice(0, PERMISSION_TEAM_LIMIT), ...memberOptions],
     hasReachedTeamLimit,
     hasReachedUserLimit,
   };
@@ -293,6 +328,7 @@ const initialState: FeedbackBoardContainerState = {
   teamEffectivenessMeasurementAverageVisibilityClassName: "hidden",
   actionItemIds: [],
   allMembers: [],
+  currentTeamMembers: [],
   castedVoteCount: 0,
   currentVoteCount: "0",
   teamVoteCapacity: 0,
@@ -1356,6 +1392,15 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     return deduplicateTeamMembers(memberLists.flatMap(members => members ?? []));
   };
 
+  const loadMembersForTeam = async (team: WebApiTeam | null | undefined): Promise<TeamMember[]> => {
+    if (!team?.id) {
+      return [];
+    }
+
+    const members = await azureDevOpsCoreService.getMembers(projectId, team.id);
+    return deduplicateTeamMembers(members ?? []);
+  };
+
   const sortTeamsByName = (teams: WebApiTeam[]): WebApiTeam[] => {
     return teams.sort((t1, t2) => {
       return t1.name.localeCompare(t2.name, [], { sensitivity: "accent" });
@@ -1373,8 +1418,8 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
       isAllTeamsLoaded: false,
     }));
 
-    loadMembersForTeams(memberTeams)
-      .then(allMembers => setContainerState(previousState => ({ ...previousState, allMembers })))
+    Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(defaultTeam)])
+      .then(([allMembers, currentTeamMembers]) => setContainerState(previousState => ({ ...previousState, allMembers, currentTeamMembers })))
       .catch(error => appInsights.trackException(error, { action: "initializeProjectTeamMembers" }));
   };
 
@@ -1382,11 +1427,12 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     const allTeams = sortTeamsByName(await azureDevOpsCoreService.getAllTeams(projectId, false));
     const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams, ...(state.userTeams ?? [])]);
     const memberTeams = uniqueItemsById([state.currentTeam, ...projectTeams]);
-    const allMembers = await loadMembersForTeams(memberTeams);
+    const [allMembers, currentTeamMembers] = await Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(state.currentTeam)]);
 
     setContainerState(previousState => ({
       ...previousState,
       allMembers,
+      currentTeamMembers,
       projectTeams,
       filteredProjectTeams: projectTeams,
       isAllTeamsLoaded: true,
@@ -1488,6 +1534,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
 
       if (matchedTeam) {
         let boardsForTeam = await BoardDataService.getBoardsForTeam(matchedTeam.id);
+        const currentTeamMembers = await loadMembersForTeam(matchedTeam);
         if (boardsForTeam?.length) {
           boardsForTeam = boardsForTeam
             .filter((board: IFeedbackBoardDocument) =>
@@ -1507,6 +1554,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
               boards: boardsForTeam?.length ? boardsForTeam : [],
               currentBoard: boardsForTeam?.length ? boardsForTeam[0] : null,
               currentTeam: matchedTeam,
+              currentTeamMembers,
               isTeamDataLoaded: true,
             };
           }
@@ -2074,6 +2122,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
       isNewBoardCreation,
       currentTeam: state.currentTeam,
       projectTeams: state.projectTeams,
+      currentTeamMembers: state.currentTeamMembers,
       allMembers: state.allMembers,
     });
 

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1441,7 +1441,8 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
       const batchResults = await Promise.all(batch.map(team => azureDevOpsCoreService.getMembers(projectId, team.id)));
       accumulated.push(...batchResults.flatMap(members => members ?? []));
 
-      if (deduplicateTeamMembers(accumulated).length >= PERMISSION_USER_LIMIT) {
+      const uniqueNonGroupCount = deduplicateTeamMembers(accumulated).filter(member => !isGroupIdentity(member.identity)).length;
+      if (uniqueNonGroupCount >= PERMISSION_USER_LIMIT) {
         break;
       }
     }

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -130,6 +130,7 @@ export function deduplicateTeamMembers(allTeamMembers: TeamMember[]): TeamMember
 
 const PERMISSION_TEAM_LIMIT = 100;
 const PERMISSION_USER_LIMIT = 500;
+const MEMBER_LOAD_CONCURRENCY = 5;
 
 function uniqueItemsById<T extends { id?: string }>(items: Array<T | null | undefined>): T[] {
   const seenIds = new Set<string>();
@@ -1421,8 +1422,19 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
   };
 
   const loadMembersForTeams = async (teams: WebApiTeam[]): Promise<TeamMember[]> => {
-    const memberLists = await Promise.all(teams.map(team => azureDevOpsCoreService.getMembers(projectId, team.id)));
-    return deduplicateTeamMembers(memberLists.flatMap(members => members ?? []));
+    const accumulated: TeamMember[] = [];
+
+    for (let i = 0; i < teams.length; i += MEMBER_LOAD_CONCURRENCY) {
+      const batch = teams.slice(i, i + MEMBER_LOAD_CONCURRENCY);
+      const batchResults = await Promise.all(batch.map(team => azureDevOpsCoreService.getMembers(projectId, team.id)));
+      accumulated.push(...batchResults.flatMap(members => members ?? []));
+
+      if (deduplicateTeamMembers(accumulated).length >= PERMISSION_USER_LIMIT) {
+        break;
+      }
+    }
+
+    return deduplicateTeamMembers(accumulated);
   };
 
   const loadMembersForTeam = async (team: WebApiTeam | null | undefined): Promise<TeamMember[]> => {

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -2322,7 +2322,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     return <div>{t("feedback_board_team_list_error")}</div>;
   }
 
-  const selectableTeams = showAllTeams && state.projectTeams.length ? state.projectTeams : state.userTeams.length ? state.userTeams : [state.currentTeam];
+  const selectableTeams = showAllTeams && state.projectTeams.length ? state.projectTeams : uniqueItemsById([state.currentTeam, ...(state.userTeams.length ? state.userTeams : [state.currentTeam])]);
 
   const handleShowAllTeamsChange = async (shouldShowAllTeams: boolean): Promise<void> => {
     if (!shouldShowAllTeams) {

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1464,9 +1464,10 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     });
   };
 
-  const initializeProjectTeams = (defaultTeam: WebApiTeam, userTeams: WebApiTeam[]) => {
+  const initializeProjectTeams = (defaultTeam: WebApiTeam | null | undefined, userTeams: WebApiTeam[]) => {
     const projectTeams = uniqueItemsById([defaultTeam, ...(userTeams ?? [])]);
-    const memberTeams = projectTeams.filter(team => team.id !== defaultTeam.id);
+    const defaultTeamId = defaultTeam?.id;
+    const memberTeams = defaultTeamId ? projectTeams.filter(team => team.id !== defaultTeamId) : projectTeams;
 
     setContainerState(previousState => ({
       ...previousState,

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -298,7 +298,7 @@ export function buildPermissionOptions(args: {
   const additionalMemberAllowance = Math.max(PERMISSION_USER_LIMIT - currentTeamMemberIds.size, 0);
   const additionalMemberCandidates = deduplicateTeamMembers(args.allMembers).filter(member => {
     const memberId = member?.identity?.id;
-    return !!memberId && !currentTeamMemberIds.has(memberId);
+    return !!memberId && !currentTeamMemberIds.has(memberId) && !isGroupIdentity(member.identity);
   });
 
   let additionalMemberCount = 0;

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -211,6 +211,7 @@ export interface PermissionOptionsBuildResult {
 export function buildPermissionOptions(args: {
   board: IFeedbackBoardDocument | null | undefined;
   currentUserId: string;
+  currentUserIsTeamAdmin?: boolean;
   isNewBoardCreation: boolean;
   currentTeam: WebApiTeam | null | undefined;
   projectTeams: WebApiTeam[];
@@ -279,7 +280,7 @@ export function buildPermissionOptions(args: {
     return true;
   };
 
-  addMemberOption(currentUserIdentity);
+  addMemberOption(currentUserIdentity, args.currentUserIsTeamAdmin);
   addMemberOption(ownerIdentity);
   for (const permissionMemberId of permissionMembers) {
     const resolvedMember = memberLookup.get(permissionMemberId);
@@ -2151,6 +2152,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     const permissionOptionsBuildResult = buildPermissionOptions({
       board: state.currentBoard,
       currentUserId: state.currentUserId,
+      currentUserIsTeamAdmin,
       isNewBoardCreation,
       currentTeam: state.currentTeam,
       projectTeams: showAllTeams ? state.projectTeams : state.userTeams,

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -127,6 +127,133 @@ export function deduplicateTeamMembers(allTeamMembers: TeamMember[]): TeamMember
   });
 }
 
+const PERMISSION_TEAM_LIMIT = 100;
+const PERMISSION_USER_LIMIT = 500;
+
+function uniqueItemsById<T extends { id?: string }>(items: Array<T | null | undefined>): T[] {
+  const seenIds = new Set<string>();
+  const uniqueItems: T[] = [];
+
+  for (const item of items) {
+    if (!item?.id || seenIds.has(item.id)) {
+      continue;
+    }
+
+    seenIds.add(item.id);
+    uniqueItems.push(item);
+  }
+
+  return uniqueItems;
+}
+
+function toTeamPermissionOption(team: WebApiTeam): FeedbackBoardPermissionOption {
+  return {
+    id: team.id,
+    name: team.name || team.id,
+    uniqueName: team.projectName || team.name || team.id,
+    type: "team",
+  };
+}
+
+function toMemberPermissionOption(member: TeamMember["identity"], isTeamAdmin?: boolean): FeedbackBoardPermissionOption {
+  return {
+    id: member.id,
+    name: member.displayName || member.uniqueName || member.id,
+    uniqueName: member.uniqueName || member.id,
+    thumbnailUrl: member.imageUrl,
+    type: "member",
+    isTeamAdmin,
+  };
+}
+
+function getOwnerIdentity(board: IFeedbackBoardDocument | null | undefined, isNewBoardCreation: boolean, currentUserId: string): TeamMember["identity"] | null {
+  if (isNewBoardCreation) {
+    const currentUser = getUserIdentity();
+    if (currentUser?.id) {
+      return currentUser;
+    }
+
+    return currentUserId ? ({ id: currentUserId, displayName: currentUserId, uniqueName: currentUserId } as TeamMember["identity"]) : null;
+  }
+
+  return board?.createdBy ?? null;
+}
+
+export interface PermissionOptionsBuildResult {
+  permissionOptions: FeedbackBoardPermissionOption[];
+  hasReachedTeamLimit: boolean;
+  hasReachedUserLimit: boolean;
+}
+
+export function buildPermissionOptions(args: {
+  board: IFeedbackBoardDocument | null | undefined;
+  currentUserId: string;
+  isNewBoardCreation: boolean;
+  currentTeam: WebApiTeam | null | undefined;
+  projectTeams: WebApiTeam[];
+  allMembers: TeamMember[];
+}): PermissionOptionsBuildResult {
+  const ownerIdentity = getOwnerIdentity(args.board, args.isNewBoardCreation, args.currentUserId);
+  const permissionTeams = args.board?.permissions?.Teams ?? [];
+  const permissionMembers = args.board?.permissions?.Members ?? [];
+
+  const teamLookup = new Map<string, WebApiTeam>();
+  for (const team of uniqueItemsById([args.currentTeam, ...args.projectTeams])) {
+    teamLookup.set(team.id, team);
+  }
+
+  const memberLookup = new Map<string, TeamMember>();
+  for (const member of args.allMembers) {
+    if (member?.identity?.id) {
+      memberLookup.set(member.identity.id, member);
+    }
+  }
+
+  const teamOptions: FeedbackBoardPermissionOption[] = [];
+  const addTeamOption = (team: WebApiTeam | null | undefined): void => {
+    if (!team?.id || teamOptions.some(option => option.id === team.id)) {
+      return;
+    }
+
+    teamOptions.push(toTeamPermissionOption(team));
+  };
+
+  addTeamOption(args.currentTeam);
+  for (const permissionTeamId of permissionTeams) {
+    addTeamOption(teamLookup.get(permissionTeamId) ?? ({ id: permissionTeamId, name: permissionTeamId, projectName: permissionTeamId } as WebApiTeam));
+  }
+  for (const projectTeam of args.projectTeams) {
+    addTeamOption(projectTeam);
+  }
+
+  const memberOptions: FeedbackBoardPermissionOption[] = [];
+  const addMemberOption = (memberIdentity: TeamMember["identity"] | null | undefined, isTeamAdmin?: boolean): void => {
+    if (!memberIdentity?.id || memberOptions.some(option => option.id === memberIdentity.id)) {
+      return;
+    }
+
+    memberOptions.push(toMemberPermissionOption(memberIdentity, isTeamAdmin));
+  };
+
+  addMemberOption(ownerIdentity);
+  for (const permissionMemberId of permissionMembers) {
+    const resolvedMember = memberLookup.get(permissionMemberId);
+    addMemberOption(resolvedMember?.identity ?? ({ id: permissionMemberId, displayName: permissionMemberId, uniqueName: permissionMemberId } as TeamMember["identity"]), resolvedMember?.isTeamAdmin);
+  }
+  for (const member of args.allMembers) {
+    addMemberOption(member.identity, member.isTeamAdmin);
+  }
+
+  const hasReachedTeamLimit = teamOptions.length > PERMISSION_TEAM_LIMIT;
+  const hasReachedUserLimit = memberOptions.length > PERMISSION_USER_LIMIT;
+
+  return {
+    permissionOptions: [...teamOptions.slice(0, PERMISSION_TEAM_LIMIT), ...memberOptions.slice(0, PERMISSION_USER_LIMIT)],
+    hasReachedTeamLimit,
+    hasReachedUserLimit,
+  };
+}
+
 const initialState: FeedbackBoardContainerState = {
   allWorkItemTypes: [],
   availableActionItemWorkItemTypes: [],
@@ -1226,7 +1353,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
 
   const loadMembersForTeams = async (teams: WebApiTeam[]): Promise<TeamMember[]> => {
     const memberLists = await Promise.all(teams.map(team => azureDevOpsCoreService.getMembers(projectId, team.id)));
-    return deduplicateTeamMembers(memberLists.flat());
+    return deduplicateTeamMembers(memberLists.flatMap(members => members ?? []));
   };
 
   const sortTeamsByName = (teams: WebApiTeam[]): WebApiTeam[] => {
@@ -1236,7 +1363,8 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
   };
 
   const initializeProjectTeams = (defaultTeam: WebApiTeam, userTeams: WebApiTeam[]) => {
-    const projectTeams = userTeams?.length > 0 ? userTeams : defaultTeam ? [defaultTeam] : [];
+    const projectTeams = uniqueItemsById([defaultTeam, ...(userTeams ?? [])]);
+    const memberTeams = uniqueItemsById([defaultTeam, ...projectTeams]);
 
     setContainerState(previousState => ({
       ...previousState,
@@ -1245,15 +1373,16 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
       isAllTeamsLoaded: false,
     }));
 
-    loadMembersForTeams(projectTeams)
+    loadMembersForTeams(memberTeams)
       .then(allMembers => setContainerState(previousState => ({ ...previousState, allMembers })))
       .catch(error => appInsights.trackException(error, { action: "initializeProjectTeamMembers" }));
   };
 
   const loadAllProjectTeams = async (): Promise<void> => {
     const allTeams = sortTeamsByName(await azureDevOpsCoreService.getAllTeams(projectId, false));
-    const projectTeams = allTeams.length ? allTeams : state.userTeams.length ? state.userTeams : state.currentTeam ? [state.currentTeam] : [];
-    const allMembers = await loadMembersForTeams(projectTeams);
+    const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams, ...(state.userTeams ?? [])]);
+    const memberTeams = uniqueItemsById([state.currentTeam, ...projectTeams]);
+    const allMembers = await loadMembersForTeams(memberTeams);
 
     setContainerState(previousState => ({
       ...previousState,
@@ -1926,26 +2055,6 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     downloadPdfBlob(pdfBlob, fileName);
   };
 
-  const permissionOptions = React.useMemo<FeedbackBoardPermissionOption[]>(
-    () => [
-      ...state.projectTeams.map(team => ({
-        id: team.id,
-        name: team.name,
-        uniqueName: team.projectName,
-        type: "team" as const,
-      })),
-      ...state.allMembers.map(member => ({
-        id: member.identity.id,
-        name: member.identity.displayName,
-        uniqueName: member.identity.uniqueName,
-        thumbnailUrl: member.identity.imageUrl,
-        type: "member" as const,
-        isTeamAdmin: member.isTeamAdmin,
-      })),
-    ],
-    [state.projectTeams, state.allMembers],
-  );
-
   const renderBoardUpdateMetadataFormDialog = (
     dialogRef: React.RefObject<HTMLDialogElement>,
     isNewBoardCreation: boolean,
@@ -1959,6 +2068,15 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     initialTitleOverride?: string,
     onDialogClose?: () => void,
   ) => {
+    const permissionOptionsBuildResult = buildPermissionOptions({
+      board: state.currentBoard,
+      currentUserId: state.currentUserId,
+      isNewBoardCreation,
+      currentTeam: state.currentTeam,
+      projectTeams: state.projectTeams,
+      allMembers: state.allMembers,
+    });
+
     return (
       <dialog className="board-metadata-dialog dialog-width-lg" ref={dialogRef} role="dialog" aria-label={dialogTitle} onClose={onDialogClose}>
         <div className="header">
@@ -1967,7 +2085,21 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
             {getIconElement("close")}
           </button>
         </div>
-        <FeedbackBoardMetadataForm isNewBoardCreation={isNewBoardCreation} isDuplicatingBoard={isDuplicatingBoard} currentBoard={state.currentBoard} initialTitleOverride={initialTitleOverride} canManageBoard={canManageCurrentBoard} teamId={state.currentTeam.id} maxVotesPerUser={state.maxVotesPerUser} placeholderText={placeholderText} availablePermissionOptions={permissionOptions} currentUserId={state.currentUserId} onFormSubmit={onSubmit} onFormCancel={onCancel} />
+        <FeedbackBoardMetadataForm
+          isNewBoardCreation={isNewBoardCreation}
+          isDuplicatingBoard={isDuplicatingBoard}
+          currentBoard={state.currentBoard}
+          initialTitleOverride={initialTitleOverride}
+          canManageBoard={canManageCurrentBoard}
+          teamId={state.currentTeam.id}
+          maxVotesPerUser={state.maxVotesPerUser}
+          placeholderText={placeholderText}
+          availablePermissionOptions={permissionOptionsBuildResult.permissionOptions}
+          currentUserId={state.currentUserId}
+          permissionLimitReached={{ users: permissionOptionsBuildResult.hasReachedUserLimit, teams: permissionOptionsBuildResult.hasReachedTeamLimit }}
+          onFormSubmit={onSubmit}
+          onFormCancel={onCancel}
+        />
       </dialog>
     );
   };

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -174,6 +174,10 @@ function isGroupIdentity(memberIdentity: TeamMember["identity"] | null | undefin
   return /^\[[^\]]+\]\\/.test(identityName);
 }
 
+function getUniqueNonGroupMemberCount(members: TeamMember[]): number {
+  return deduplicateTeamMembers(members).filter(member => member?.identity?.id && !isGroupIdentity(member.identity)).length;
+}
+
 function getOwnerIdentity(board: IFeedbackBoardDocument | null | undefined, isNewBoardCreation: boolean, currentUserId: string): TeamMember["identity"] | null {
   if (isNewBoardCreation) {
     const currentUser = getUserIdentity();
@@ -1435,7 +1439,11 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     }
   };
 
-  const loadMembersForTeams = async (teams: WebApiTeam[]): Promise<{ members: TeamMember[]; didHitLimit: boolean }> => {
+  const loadMembersForTeams = async (teams: WebApiTeam[], additionalMemberAllowance: number): Promise<{ members: TeamMember[]; didHitLimit: boolean }> => {
+    if (additionalMemberAllowance <= 0) {
+      return { members: [], didHitLimit: false };
+    }
+
     const accumulated: TeamMember[] = [];
     let didHitLimit = false;
 
@@ -1444,8 +1452,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
       const batchResults = await Promise.all(batch.map(team => azureDevOpsCoreService.getMembers(projectId, team.id)));
       accumulated.push(...batchResults.flatMap(members => members ?? []));
 
-      const uniqueNonGroupCount = deduplicateTeamMembers(accumulated).filter(member => !isGroupIdentity(member.identity)).length;
-      if (uniqueNonGroupCount >= PERMISSION_USER_LIMIT) {
+      if (getUniqueNonGroupMemberCount(accumulated) >= additionalMemberAllowance) {
         didHitLimit = true;
         break;
       }
@@ -1481,15 +1488,18 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
       isAllTeamsLoaded: false,
     }));
 
-    Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(defaultTeam)])
-      .then(([additionalMembersResult, currentTeamMembers]) =>
+    loadMembersForTeam(defaultTeam)
+      .then(async currentTeamMembers => {
+        const additionalMemberAllowance = Math.max(PERMISSION_USER_LIMIT - getUniqueNonGroupMemberCount(currentTeamMembers), 0);
+        const additionalMembersResult = await loadMembersForTeams(memberTeams, additionalMemberAllowance);
+
         setContainerState(previousState => ({
           ...previousState,
           allMembers: deduplicateTeamMembers([...currentTeamMembers, ...additionalMembersResult.members]),
           currentTeamMembers,
           hasReachedAdditionalMemberLoadLimit: additionalMembersResult.didHitLimit,
-        })),
-      )
+        }));
+      })
       .catch(error => appInsights.trackException(error, { action: "initializeProjectTeamMembers" }));
   };
 
@@ -1497,7 +1507,9 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
     const allTeams = sortTeamsByName(await azureDevOpsCoreService.getAllTeams(projectId, false));
     const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams]);
     const memberTeams = projectTeams.filter(team => team.id !== state.currentTeam?.id);
-    const [additionalMembersResult, currentTeamMembers] = await Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(state.currentTeam)]);
+    const currentTeamMembers = await loadMembersForTeam(state.currentTeam);
+    const additionalMemberAllowance = Math.max(PERMISSION_USER_LIMIT - getUniqueNonGroupMemberCount(currentTeamMembers), 0);
+    const additionalMembersResult = await loadMembersForTeams(memberTeams, additionalMemberAllowance);
 
     setContainerState(previousState => ({
       ...previousState,

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -253,7 +253,20 @@ export function buildPermissionOptions(args: {
 
   const memberOptions: FeedbackBoardPermissionOption[] = [];
   const addMemberOption = (memberIdentity: TeamMember["identity"] | null | undefined, isTeamAdmin?: boolean): boolean => {
-    if (!memberIdentity?.id || memberOptions.some(option => option.id === memberIdentity.id)) {
+    if (!memberIdentity?.id) {
+      return false;
+    }
+
+    const existingOption = memberOptions.find(option => option.id === memberIdentity.id);
+    if (existingOption) {
+      if (isTeamAdmin && !existingOption.isTeamAdmin) {
+        existingOption.isTeamAdmin = true;
+      }
+
+      if (!existingOption.thumbnailUrl && memberIdentity.imageUrl) {
+        existingOption.thumbnailUrl = memberIdentity.imageUrl;
+      }
+
       return false;
     }
 

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -302,8 +302,10 @@ export function buildPermissionOptions(args: {
   });
 
   let additionalMemberCount = 0;
+  let hasReachedUserLimit = false;
   for (const member of additionalMemberCandidates) {
     if (additionalMemberCount >= additionalMemberAllowance) {
+      hasReachedUserLimit = true;
       break;
     }
 
@@ -313,8 +315,6 @@ export function buildPermissionOptions(args: {
   }
 
   const hasReachedTeamLimit = teamOptions.length > PERMISSION_TEAM_LIMIT;
-  const hasReachedUserLimit = additionalMemberCandidates.length > additionalMemberCount;
-
   return {
     permissionOptions: [...teamOptions.slice(0, PERMISSION_TEAM_LIMIT), ...memberOptions],
     hasReachedTeamLimit,

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1425,7 +1425,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
 
   const loadAllProjectTeams = async (): Promise<void> => {
     const allTeams = sortTeamsByName(await azureDevOpsCoreService.getAllTeams(projectId, false));
-    const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams]).slice(0, PERMISSION_TEAM_LIMIT);
+    const projectTeams = uniqueItemsById([state.currentTeam, ...allTeams]);
     const memberTeams = uniqueItemsById([state.currentTeam, ...projectTeams]);
     const [allMembers, currentTeamMembers] = await Promise.all([loadMembersForTeams(memberTeams), loadMembersForTeam(state.currentTeam)]);
 

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -130,7 +130,7 @@ export function deduplicateTeamMembers(allTeamMembers: TeamMember[]): TeamMember
 }
 
 const PERMISSION_TEAM_LIMIT = 100;
-const PERMISSION_USER_LIMIT = 500;
+const PERMISSION_USER_LIMIT = 200;
 const MEMBER_LOAD_CONCURRENCY = 5;
 
 function uniqueItemsById<T extends { id?: string }>(items: Array<T | null | undefined>): T[] {

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -1458,7 +1458,11 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
       }
     }
 
-    return { members: deduplicateTeamMembers(accumulated), didHitLimit };
+    const members = deduplicateTeamMembers(accumulated)
+      .filter(member => member?.identity?.id && !isGroupIdentity(member.identity))
+      .slice(0, additionalMemberAllowance);
+
+    return { members, didHitLimit };
   };
 
   const loadMembersForTeam = async (team: WebApiTeam | null | undefined): Promise<TeamMember[]> => {

--- a/src/frontend/components/feedbackBoardMetadataForm.tsx
+++ b/src/frontend/components/feedbackBoardMetadataForm.tsx
@@ -24,6 +24,10 @@ export interface IFeedbackBoardMetadataFormProps {
   maxVotesPerUser: number;
   availablePermissionOptions: FeedbackBoardPermissionOption[];
   currentUserId: string;
+  permissionLimitReached?: {
+    users: boolean;
+    teams: boolean;
+  };
   onFormSubmit: (title: string, maxVotesPerUser: number, columns: IFeedbackColumn[], isIncludeTeamEffectivenessMeasurement: boolean, shouldShowFeedbackAfterCollect: boolean, isBoardAnonymous: boolean, permissions: IFeedbackBoardDocumentPermissions, teamAssessmentQuestions: ITeamAssessmentQuestion[]) => void;
   onFormCancel: () => void;
 }
@@ -131,7 +135,7 @@ const getInitialState = (props: IFeedbackBoardMetadataFormProps) => {
 };
 
 export const FeedbackBoardMetadataForm: React.FC<IFeedbackBoardMetadataFormProps> = props => {
-  const { isNewBoardCreation, isDuplicatingBoard, currentBoard, canManageBoard = true, teamId, placeholderText, availablePermissionOptions, currentUserId, onFormSubmit, onFormCancel } = props;
+  const { isNewBoardCreation, isDuplicatingBoard, currentBoard, canManageBoard = true, teamId, placeholderText, availablePermissionOptions, currentUserId, permissionLimitReached, onFormSubmit, onFormCancel } = props;
   const trackActivity = useTrackMetric(reactPlugin, "FeedbackBoardMetadataForm");
 
   const [initialState] = useState(() => getInitialState(props));
@@ -668,7 +672,16 @@ export const FeedbackBoardMetadataForm: React.FC<IFeedbackBoardMetadataFormProps
         {activeMetadataTab === "Permissions" && (
           <div id="board-metadata-permissions-panel" className="board-metadata-form" role="tabpanel" aria-labelledby="board-metadata-permissions-tab">
             {!canManageBoard && <div className="board-metadata-form-section-information board-metadata-read-only-banner">{getIconElement("exclamation")} {t("feedback_board_view_only_message")}</div>}
-            <FeedbackBoardMetadataFormPermissions board={currentBoard} permissions={permissions} permissionOptions={availablePermissionOptions} currentUserId={currentUserId} isNewBoardCreation={isNewBoardCreation} canManageBoard={canManageBoard} onPermissionChanged={(s: FeedbackBoardPermissionState) => setPermissions(s.permissions)} />
+            <FeedbackBoardMetadataFormPermissions
+              board={currentBoard}
+              permissions={permissions}
+              permissionOptions={availablePermissionOptions}
+              currentUserId={currentUserId}
+              isNewBoardCreation={isNewBoardCreation}
+              canManageBoard={canManageBoard}
+              permissionLimitReached={permissionLimitReached}
+              onPermissionChanged={(s: FeedbackBoardPermissionState) => setPermissions(s.permissions)}
+            />
           </div>
         )}
       </div>

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -231,15 +231,15 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     const hasTeamLimit = props.permissionLimitReached?.teams;
 
     if (hasUserLimit && hasTeamLimit) {
-      return "All current team users are shown. Additional users and teams are limited to 10.";
+      return "Only the first 500 users and 100 teams are shown.";
     }
 
     if (hasUserLimit) {
-      return "All current team users are shown. Additional users from other teams are limited to 10.";
+      return "Only the first 500 users are shown.";
     }
 
     if (hasTeamLimit) {
-      return "Only the first 10 teams are shown.";
+      return "Only the first 100 teams are shown.";
     }
 
     return null;

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -231,11 +231,11 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     const hasTeamLimit = props.permissionLimitReached?.teams;
 
     if (hasUserLimit && hasTeamLimit) {
-      return "Only the first 5 users and 5 teams are shown.";
+      return "All current team users are shown. Additional users and teams are limited to 5.";
     }
 
     if (hasUserLimit) {
-      return "Only the first 5 users are shown.";
+      return "All current team users are shown. Additional users from other teams are limited to 5.";
     }
 
     if (hasTeamLimit) {

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -231,15 +231,15 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     const hasTeamLimit = props.permissionLimitReached?.teams;
 
     if (hasUserLimit && hasTeamLimit) {
-      return "Reached 500 user and 100 team retrieval limit.";
+      return "Additional results are capped at 500 users and 100 teams.";
     }
 
     if (hasUserLimit) {
-      return "Reached 500 user retrieval limit.";
+      return "Additional results are capped at 500 users.";
     }
 
     if (hasTeamLimit) {
-      return "Reached 100 team retrieval limit.";
+      return "Additional results are capped at 100 teams.";
     }
 
     return null;

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -231,7 +231,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     const hasTeamLimit = props.permissionLimitReached?.teams;
 
     if (hasUserLimit && hasTeamLimit) {
-      return "Reached 500 user or 100 team retrieval limit.";
+      return "Reached 500 user and 100 team retrieval limit.";
     }
 
     if (hasUserLimit) {

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -11,6 +11,10 @@ export interface IFeedbackBoardMetadataFormPermissionsProps {
   currentUserId: string;
   isNewBoardCreation: boolean;
   canManageBoard: boolean;
+  permissionLimitReached?: {
+    users: boolean;
+    teams: boolean;
+  };
   onPermissionChanged: (state: FeedbackBoardPermissionState) => void;
 }
 
@@ -226,6 +230,8 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     <div className="board-metadata-form board-metadata-form-permissions" onKeyDown={trackActivity} onMouseMove={trackActivity} onTouchStart={trackActivity}>
       <section className="board-metadata-form-board-settings board-metadata-form-board-settings--no-padding">
         <PublicWarningBanner isVisible={teamPermissions.length === 0 && memberPermissions.length === 0} />
+        {props.permissionLimitReached?.users && <div className="board-metadata-form-section-information">{getIconElement("exclamation")} Only the first 500 users are shown.</div>}
+        {props.permissionLimitReached?.teams && <div className="board-metadata-form-section-information">{getIconElement("exclamation")} Only the first 100 teams are shown.</div>}
 
         <div className="search-bar">
           <PermissionSearchInput searchTerm={searchTerm} onSearchTermChanged={handleSearchTermChanged} />

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -231,15 +231,15 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     const hasTeamLimit = props.permissionLimitReached?.teams;
 
     if (hasUserLimit && hasTeamLimit) {
-      return "All current team users are shown. Additional users and teams are limited to 5.";
+      return "All current team users are shown. Additional users and teams are limited to 10.";
     }
 
     if (hasUserLimit) {
-      return "All current team users are shown. Additional users from other teams are limited to 5.";
+      return "All current team users are shown. Additional users from other teams are limited to 10.";
     }
 
     if (hasTeamLimit) {
-      return "Only the first 5 teams are shown.";
+      return "Only the first 10 teams are shown.";
     }
 
     return null;

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -226,12 +226,32 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     emitChangeEvent();
   }, [teamPermissions, memberPermissions]);
 
+  const permissionLimitMessage = React.useMemo(() => {
+    const hasUserLimit = props.permissionLimitReached?.users;
+    const hasTeamLimit = props.permissionLimitReached?.teams;
+
+    if (hasUserLimit && hasTeamLimit) {
+      return "Only the first 5 users and 5 teams are shown.";
+    }
+
+    if (hasUserLimit) {
+      return "Only the first 5 users are shown.";
+    }
+
+    if (hasTeamLimit) {
+      return "Only the first 5 teams are shown.";
+    }
+
+    return null;
+  }, [props.permissionLimitReached?.teams, props.permissionLimitReached?.users]);
+
   return (
     <div className="board-metadata-form board-metadata-form-permissions" onKeyDown={trackActivity} onMouseMove={trackActivity} onTouchStart={trackActivity}>
       <section className="board-metadata-form-board-settings board-metadata-form-board-settings--no-padding">
-        <PublicWarningBanner isVisible={teamPermissions.length === 0 && memberPermissions.length === 0} />
-        {props.permissionLimitReached?.users && <div className="board-metadata-form-section-information">{getIconElement("exclamation")} Only the first 5 users are shown.</div>}
-        {props.permissionLimitReached?.teams && <div className="board-metadata-form-section-information">{getIconElement("exclamation")} Only the first 5 teams are shown.</div>}
+        <div className="permission-info-messages">
+          <PublicWarningBanner isVisible={teamPermissions.length === 0 && memberPermissions.length === 0} />
+          {permissionLimitMessage && <div className="board-metadata-form-section-information">{getIconElement("exclamation")} {permissionLimitMessage}</div>}
+        </div>
 
         <div className="search-bar">
           <PermissionSearchInput searchTerm={searchTerm} onSearchTermChanged={handleSearchTermChanged} />

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -231,11 +231,11 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     const hasTeamLimit = props.permissionLimitReached?.teams;
 
     if (hasUserLimit && hasTeamLimit) {
-      return "Only the first 500 users and 100 teams are shown.";
+      return "Only the first 500 additional users and 100 teams are shown.";
     }
 
     if (hasUserLimit) {
-      return "Only the first 500 users are shown.";
+      return "Only the first 500 additional users are shown.";
     }
 
     if (hasTeamLimit) {

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -230,8 +230,8 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     <div className="board-metadata-form board-metadata-form-permissions" onKeyDown={trackActivity} onMouseMove={trackActivity} onTouchStart={trackActivity}>
       <section className="board-metadata-form-board-settings board-metadata-form-board-settings--no-padding">
         <PublicWarningBanner isVisible={teamPermissions.length === 0 && memberPermissions.length === 0} />
-        {props.permissionLimitReached?.users && <div className="board-metadata-form-section-information">{getIconElement("exclamation")} Only the first 500 users are shown.</div>}
-        {props.permissionLimitReached?.teams && <div className="board-metadata-form-section-information">{getIconElement("exclamation")} Only the first 100 teams are shown.</div>}
+        {props.permissionLimitReached?.users && <div className="board-metadata-form-section-information">{getIconElement("exclamation")} Only the first 5 users are shown.</div>}
+        {props.permissionLimitReached?.teams && <div className="board-metadata-form-section-information">{getIconElement("exclamation")} Only the first 5 teams are shown.</div>}
 
         <div className="search-bar">
           <PermissionSearchInput searchTerm={searchTerm} onSearchTermChanged={handleSearchTermChanged} />

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -231,15 +231,15 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     const hasTeamLimit = props.permissionLimitReached?.teams;
 
     if (hasUserLimit && hasTeamLimit) {
-      return "Only the first 500 additional users and 100 teams are shown.";
+      return "Reached 500 user or 100 team retrieval limit.";
     }
 
     if (hasUserLimit) {
-      return "Only the first 500 additional users are shown.";
+      return "Reached 500 user retrieval limit.";
     }
 
     if (hasTeamLimit) {
-      return "Only the first 100 teams are shown.";
+      return "Reached 100 team retrieval limit.";
     }
 
     return null;

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -231,15 +231,15 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     const hasTeamLimit = props.permissionLimitReached?.teams;
 
     if (hasUserLimit && hasTeamLimit) {
-      return "Additional results are capped at 500 users and 100 teams.";
+      return "Showing up to 500 additional users and 100 additional teams.";
     }
 
     if (hasUserLimit) {
-      return "Additional results are capped at 500 users.";
+      return "Showing up to 500 additional users.";
     }
 
     if (hasTeamLimit) {
-      return "Additional results are capped at 100 teams.";
+      return "Showing up to 100 additional teams.";
     }
 
     return null;

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -231,11 +231,11 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
     const hasTeamLimit = props.permissionLimitReached?.teams;
 
     if (hasUserLimit && hasTeamLimit) {
-      return "Showing up to 500 additional users and 100 additional teams.";
+      return "Showing up to 200 additional users and 100 additional teams.";
     }
 
     if (hasUserLimit) {
-      return "Showing up to 500 additional users.";
+      return "Showing up to 200 additional users.";
     }
 
     if (hasTeamLimit) {

--- a/src/frontend/components/whatsNewDialog.tsx
+++ b/src/frontend/components/whatsNewDialog.tsx
@@ -9,7 +9,7 @@ interface IWhatsNewDialogProps {
 const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.60 and v1.92.59 include:";
 
 const WHATS_NEW_ITEMS = [
-  "Improved permission loading and prioritization, with hard caps of 500 users and 100 teams.",
+  "Improved permission loading and prioritization, with hard caps of 200 users and 100 teams.",
   "Added a Move Everyone control so board managers can move all participants to the selected retrospective phase.",
   "Expanded feedback search to include archived boards.",
   "Fixed a Focus Mode render loop that could cause constant CPU usage.",

--- a/src/frontend/components/whatsNewDialog.tsx
+++ b/src/frontend/components/whatsNewDialog.tsx
@@ -6,25 +6,15 @@ interface IWhatsNewDialogProps {
   dialogRef: React.RefObject<HTMLDialogElement | null>;
 }
 
-const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.59, v1.92.58, v1.92.57, and v1.92.56 include:";
+const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.60 and v1.92.59 include:";
 
 const WHATS_NEW_ITEMS = [
+  "Improved permission loading and prioritization, with hard caps of 500 users and 100 teams.",
   "Added a Move Everyone control so board managers can move all participants to the selected retrospective phase.",
   "Expanded feedback search to include archived boards.",
   "Fixed a Focus Mode render loop that could cause constant CPU usage.",
-  "Optimized board and Team Assessment History rendering to reduce unnecessary updates.",
-  "Improved team and board loading, including default-team lookup and recovery from local-network access restrictions.",
-  "Fixed retrospective board links for Azure DevOps organizations.",
-  "Added longer column titles.",
-  "Added sort-direction indicators to History table.",
-  "Added user settings to toggle between show all teams or my teams and to toggle between scrolling by board or by column.",
   "Restricted editing of retrospective settings to the Board Owner and Team Admin.",
-  "Fixed the email summary Copy to clipboard action so it works reliably from the preview dialog.",
-  "Extended permissions so team admins can also update column notes and edit or delete feedback cards.",
-  "Improved hidden feedback behavior to display blurred feedback while announcing \"feedback blurred\".",
-  "Added team admin setting for configuring available work item types in \"Add work item\".",
-  "Defaulted add-work-item type options to Requirement Backlog types for the Act tab and Focus mode.",
-  "Adjusted the \"Add work item\" selection to ensure the full list of work item types is visible for the Act tab and Focus mode.",
+  "Improved board settings layout and accessibility for a more consistent user experience.",
 ];
 
 const WHATS_NEW_FOOTER_TEXT = "Refer to the Changelog for a complete history of updates.";

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -169,7 +169,7 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(result).toEqual(mockMembers);
       expect(result).toHaveLength(2);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-123", "team-123", 5, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-123", "team-123", 10, 0);
     });
 
     it("should return null when members cannot be retrieved", async () => {
@@ -203,26 +203,26 @@ describe("AzureDevOpsCoreService", () => {
 
       await azureDevOpsCoreService.getMembers("project-abc", "team-xyz");
 
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-abc", "team-xyz", 5, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-abc", "team-xyz", 10, 0);
     });
 
     it("should fetch additional pages when the first page is full", async () => {
-      const firstPage: TeamMember[] = Array.from({ length: 5 }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
-      const secondPage: TeamMember[] = [{ identity: { displayName: "User 6" } } as any];
+      const firstPage: TeamMember[] = Array.from({ length: 10 }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
+      const secondPage: TeamMember[] = [{ identity: { displayName: "User 11" } } as any];
       mockGetTeamMembersWithExtendedProperties
         .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(secondPage);
 
       const result = await azureDevOpsCoreService.getMembers("project-abc", "team-xyz");
 
-      expect(result).toHaveLength(6);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(1, "project-abc", "team-xyz", 5, 0);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(2, "project-abc", "team-xyz", 5, 5);
+      expect(result).toHaveLength(11);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(1, "project-abc", "team-xyz", 10, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(2, "project-abc", "team-xyz", 10, 10);
     });
   });
 
   describe("getAllTeams", () => {
-    it("should return all teams when less than 5 teams", async () => {
+    it("should return all teams when less than 10 teams", async () => {
       const mockTeams: WebApiTeam[] = [{ id: "team-1", name: "Team 1" } as any, { id: "team-2", name: "Team 2" } as any, { id: "team-3", name: "Team 3" } as any];
 
       mockGetTeams.mockResolvedValue(mockTeams);
@@ -231,48 +231,48 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(result).toEqual(mockTeams);
       expect(result).toHaveLength(3);
-      expect(mockGetTeams).toHaveBeenCalledWith("project-123", false, 5, 0);
+      expect(mockGetTeams).toHaveBeenCalledWith("project-123", false, 10, 0);
       expect(mockGetTeams).toHaveBeenCalledTimes(1);
     });
 
-    it("should paginate when there are exactly 5 teams", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
+    it("should paginate when there are exactly 10 teams", async () => {
+      const firstBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-5", name: "Team 5" } as any, { id: "team-6", name: "Team 6" } as any];
+      const secondBatch: WebApiTeam[] = [{ id: "team-10", name: "Team 10" } as any, { id: "team-11", name: "Team 11" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(7);
+      expect(result).toHaveLength(12);
       expect(mockGetTeams).toHaveBeenCalledTimes(2);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-123", false, 5, 0);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-123", false, 5, 5);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-123", false, 10, 0);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-123", false, 10, 10);
     });
 
     it("should handle multiple pagination rounds", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
-        id: `team-${5 + i}`,
-        name: `Team ${5 + i}`,
+      const secondBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
+        id: `team-${10 + i}`,
+        name: `Team ${10 + i}`,
       })) as any;
 
-      const thirdBatch: WebApiTeam[] = [{ id: "team-10", name: "Team 10" } as any];
+      const thirdBatch: WebApiTeam[] = [{ id: "team-20", name: "Team 20" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch).mockResolvedValueOnce(thirdBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(11);
+      expect(result).toHaveLength(21);
       expect(mockGetTeams).toHaveBeenCalledTimes(3);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(3, "project-123", false, 5, 10);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(3, "project-123", false, 10, 20);
     });
 
     it("should respect forCurrentUserOnly parameter", async () => {
@@ -282,7 +282,7 @@ describe("AzureDevOpsCoreService", () => {
 
       await azureDevOpsCoreService.getAllTeams("project-456", true);
 
-      expect(mockGetTeams).toHaveBeenCalledWith("project-456", true, 5, 0);
+      expect(mockGetTeams).toHaveBeenCalledWith("project-456", true, 10, 0);
     });
 
     it("should handle empty teams list", async () => {
@@ -296,41 +296,41 @@ describe("AzureDevOpsCoreService", () => {
     });
 
     it("should accumulate teams across multiple pages", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
       const secondBatch: WebApiTeam[] = Array.from({ length: 3 }, (_, i) => ({
-        id: `team-${5 + i}`,
-        name: `Team ${5 + i}`,
+        id: `team-${10 + i}`,
+        name: `Team ${10 + i}`,
       })) as any;
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(8);
+      expect(result).toHaveLength(13);
       expect(result[0].id).toBe("team-0");
-      expect(result[4].id).toBe("team-4");
-      expect(result[5].id).toBe("team-5");
-      expect(result[7].id).toBe("team-7");
+      expect(result[9].id).toBe("team-9");
+      expect(result[10].id).toBe("team-10");
+      expect(result[12].id).toBe("team-12");
     });
 
     it("should handle different project ids in pagination", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-5", name: "Team 5" } as any];
+      const secondBatch: WebApiTeam[] = [{ id: "team-10", name: "Team 10" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       await azureDevOpsCoreService.getAllTeams("project-xyz", true);
 
-      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-xyz", true, 5, 0);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-xyz", true, 5, 5);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-xyz", true, 10, 0);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-xyz", true, 10, 10);
     });
   });
 });

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -169,7 +169,7 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(result).toEqual(mockMembers);
       expect(result).toHaveLength(2);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-123", "team-123", 100, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-123", "team-123", 5, 0);
     });
 
     it("should return null when members cannot be retrieved", async () => {
@@ -203,26 +203,26 @@ describe("AzureDevOpsCoreService", () => {
 
       await azureDevOpsCoreService.getMembers("project-abc", "team-xyz");
 
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-abc", "team-xyz", 100, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-abc", "team-xyz", 5, 0);
     });
 
     it("should fetch additional pages when the first page is full", async () => {
-      const firstPage: TeamMember[] = Array.from({ length: 100 }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
-      const secondPage: TeamMember[] = [{ identity: { displayName: "User 101" } } as any];
+      const firstPage: TeamMember[] = Array.from({ length: 5 }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
+      const secondPage: TeamMember[] = [{ identity: { displayName: "User 6" } } as any];
       mockGetTeamMembersWithExtendedProperties
         .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(secondPage);
 
       const result = await azureDevOpsCoreService.getMembers("project-abc", "team-xyz");
 
-      expect(result).toHaveLength(101);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(1, "project-abc", "team-xyz", 100, 0);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(2, "project-abc", "team-xyz", 100, 100);
+      expect(result).toHaveLength(6);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(1, "project-abc", "team-xyz", 5, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(2, "project-abc", "team-xyz", 5, 5);
     });
   });
 
   describe("getAllTeams", () => {
-    it("should return all teams when less than 100 teams", async () => {
+    it("should return all teams when less than 5 teams", async () => {
       const mockTeams: WebApiTeam[] = [{ id: "team-1", name: "Team 1" } as any, { id: "team-2", name: "Team 2" } as any, { id: "team-3", name: "Team 3" } as any];
 
       mockGetTeams.mockResolvedValue(mockTeams);
@@ -231,48 +231,48 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(result).toEqual(mockTeams);
       expect(result).toHaveLength(3);
-      expect(mockGetTeams).toHaveBeenCalledWith("project-123", false, 100, 0);
+      expect(mockGetTeams).toHaveBeenCalledWith("project-123", false, 5, 0);
       expect(mockGetTeams).toHaveBeenCalledTimes(1);
     });
 
-    it("should paginate when there are exactly 100 teams", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
+    it("should paginate when there are exactly 5 teams", async () => {
+      const firstBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-100", name: "Team 100" } as any, { id: "team-101", name: "Team 101" } as any];
+      const secondBatch: WebApiTeam[] = [{ id: "team-5", name: "Team 5" } as any, { id: "team-6", name: "Team 6" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(102);
+      expect(result).toHaveLength(7);
       expect(mockGetTeams).toHaveBeenCalledTimes(2);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-123", false, 100, 0);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-123", false, 100, 100);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-123", false, 5, 0);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-123", false, 5, 5);
     });
 
     it("should handle multiple pagination rounds", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
-        id: `team-${100 + i}`,
-        name: `Team ${100 + i}`,
+      const secondBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
+        id: `team-${5 + i}`,
+        name: `Team ${5 + i}`,
       })) as any;
 
-      const thirdBatch: WebApiTeam[] = [{ id: "team-200", name: "Team 200" } as any];
+      const thirdBatch: WebApiTeam[] = [{ id: "team-10", name: "Team 10" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch).mockResolvedValueOnce(thirdBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(201);
+      expect(result).toHaveLength(11);
       expect(mockGetTeams).toHaveBeenCalledTimes(3);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(3, "project-123", false, 100, 200);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(3, "project-123", false, 5, 10);
     });
 
     it("should respect forCurrentUserOnly parameter", async () => {
@@ -282,7 +282,7 @@ describe("AzureDevOpsCoreService", () => {
 
       await azureDevOpsCoreService.getAllTeams("project-456", true);
 
-      expect(mockGetTeams).toHaveBeenCalledWith("project-456", true, 100, 0);
+      expect(mockGetTeams).toHaveBeenCalledWith("project-456", true, 5, 0);
     });
 
     it("should handle empty teams list", async () => {
@@ -296,41 +296,41 @@ describe("AzureDevOpsCoreService", () => {
     });
 
     it("should accumulate teams across multiple pages", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = Array.from({ length: 50 }, (_, i) => ({
-        id: `team-${100 + i}`,
-        name: `Team ${100 + i}`,
+      const secondBatch: WebApiTeam[] = Array.from({ length: 3 }, (_, i) => ({
+        id: `team-${5 + i}`,
+        name: `Team ${5 + i}`,
       })) as any;
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(150);
+      expect(result).toHaveLength(8);
       expect(result[0].id).toBe("team-0");
-      expect(result[99].id).toBe("team-99");
-      expect(result[100].id).toBe("team-100");
-      expect(result[149].id).toBe("team-149");
+      expect(result[4].id).toBe("team-4");
+      expect(result[5].id).toBe("team-5");
+      expect(result[7].id).toBe("team-7");
     });
 
     it("should handle different project ids in pagination", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: 5 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-100", name: "Team 100" } as any];
+      const secondBatch: WebApiTeam[] = [{ id: "team-5", name: "Team 5" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       await azureDevOpsCoreService.getAllTeams("project-xyz", true);
 
-      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-xyz", true, 100, 0);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-xyz", true, 100, 100);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-xyz", true, 5, 0);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-xyz", true, 5, 5);
     });
   });
 });

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -205,6 +205,20 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-abc", "team-xyz", 100, 0);
     });
+
+    it("should fetch additional pages when the first page is full", async () => {
+      const firstPage: TeamMember[] = Array.from({ length: 100 }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
+      const secondPage: TeamMember[] = [{ identity: { displayName: "User 101" } } as any];
+      mockGetTeamMembersWithExtendedProperties
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(secondPage);
+
+      const result = await azureDevOpsCoreService.getMembers("project-abc", "team-xyz");
+
+      expect(result).toHaveLength(101);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(1, "project-abc", "team-xyz", 100, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(2, "project-abc", "team-xyz", 100, 100);
+    });
   });
 
   describe("getAllTeams", () => {

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -14,6 +14,8 @@ jest.mock("azure-devops-extension-api/Common", () => ({
 }));
 
 describe("AzureDevOpsCoreService", () => {
+  const MEMBERS_PAGE_SIZE = 5;
+  const TEAMS_PAGE_SIZE = 5;
   let azureDevOpsCoreService: any;
 
   beforeEach(() => {
@@ -169,7 +171,7 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(result).toEqual(mockMembers);
       expect(result).toHaveLength(2);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-123", "team-123", 100, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-123", "team-123", MEMBERS_PAGE_SIZE, 0);
     });
 
     it("should return null when members cannot be retrieved", async () => {
@@ -203,26 +205,26 @@ describe("AzureDevOpsCoreService", () => {
 
       await azureDevOpsCoreService.getMembers("project-abc", "team-xyz");
 
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-abc", "team-xyz", 100, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-abc", "team-xyz", MEMBERS_PAGE_SIZE, 0);
     });
 
     it("should fetch additional pages when the first page is full", async () => {
-      const firstPage: TeamMember[] = Array.from({ length: 100 }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
-      const secondPage: TeamMember[] = [{ identity: { displayName: "User 101" } } as any];
+      const firstPage: TeamMember[] = Array.from({ length: MEMBERS_PAGE_SIZE }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
+      const secondPage: TeamMember[] = [{ identity: { displayName: "User 6" } } as any];
       mockGetTeamMembersWithExtendedProperties
         .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(secondPage);
 
       const result = await azureDevOpsCoreService.getMembers("project-abc", "team-xyz");
 
-      expect(result).toHaveLength(101);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(1, "project-abc", "team-xyz", 100, 0);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(2, "project-abc", "team-xyz", 100, 100);
+      expect(result).toHaveLength(MEMBERS_PAGE_SIZE + 1);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(1, "project-abc", "team-xyz", MEMBERS_PAGE_SIZE, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(2, "project-abc", "team-xyz", MEMBERS_PAGE_SIZE, MEMBERS_PAGE_SIZE);
     });
   });
 
   describe("getAllTeams", () => {
-    it("should return all teams when less than 100 teams", async () => {
+    it("should return all teams when less than a full page", async () => {
       const mockTeams: WebApiTeam[] = [{ id: "team-1", name: "Team 1" } as any, { id: "team-2", name: "Team 2" } as any, { id: "team-3", name: "Team 3" } as any];
 
       mockGetTeams.mockResolvedValue(mockTeams);
@@ -231,48 +233,48 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(result).toEqual(mockTeams);
       expect(result).toHaveLength(3);
-      expect(mockGetTeams).toHaveBeenCalledWith("project-123", false, 100, 0);
+      expect(mockGetTeams).toHaveBeenCalledWith("project-123", false, TEAMS_PAGE_SIZE, 0);
       expect(mockGetTeams).toHaveBeenCalledTimes(1);
     });
 
-    it("should paginate when there are exactly 100 teams", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
+    it("should paginate when there are exactly TEAMS_PAGE_SIZE teams", async () => {
+      const firstBatch: WebApiTeam[] = Array.from({ length: TEAMS_PAGE_SIZE }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-100", name: "Team 100" } as any, { id: "team-101", name: "Team 101" } as any];
+      const secondBatch: WebApiTeam[] = [{ id: "team-5", name: "Team 5" } as any, { id: "team-6", name: "Team 6" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(102);
+      expect(result).toHaveLength(TEAMS_PAGE_SIZE + 2);
       expect(mockGetTeams).toHaveBeenCalledTimes(2);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-123", false, 100, 0);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-123", false, 100, 100);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-123", false, TEAMS_PAGE_SIZE, 0);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-123", false, TEAMS_PAGE_SIZE, TEAMS_PAGE_SIZE);
     });
 
     it("should handle multiple pagination rounds", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: TEAMS_PAGE_SIZE }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
-        id: `team-${100 + i}`,
-        name: `Team ${100 + i}`,
+      const secondBatch: WebApiTeam[] = Array.from({ length: TEAMS_PAGE_SIZE }, (_, i) => ({
+        id: `team-${TEAMS_PAGE_SIZE + i}`,
+        name: `Team ${TEAMS_PAGE_SIZE + i}`,
       })) as any;
 
-      const thirdBatch: WebApiTeam[] = [{ id: "team-200", name: "Team 200" } as any];
+      const thirdBatch: WebApiTeam[] = [{ id: "team-10", name: "Team 10" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch).mockResolvedValueOnce(thirdBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(201);
+      expect(result).toHaveLength(TEAMS_PAGE_SIZE * 2 + 1);
       expect(mockGetTeams).toHaveBeenCalledTimes(3);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(3, "project-123", false, 100, 200);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(3, "project-123", false, TEAMS_PAGE_SIZE, TEAMS_PAGE_SIZE * 2);
     });
 
     it("should respect forCurrentUserOnly parameter", async () => {
@@ -282,7 +284,7 @@ describe("AzureDevOpsCoreService", () => {
 
       await azureDevOpsCoreService.getAllTeams("project-456", true);
 
-      expect(mockGetTeams).toHaveBeenCalledWith("project-456", true, 100, 0);
+      expect(mockGetTeams).toHaveBeenCalledWith("project-456", true, TEAMS_PAGE_SIZE, 0);
     });
 
     it("should handle empty teams list", async () => {
@@ -296,41 +298,41 @@ describe("AzureDevOpsCoreService", () => {
     });
 
     it("should accumulate teams across multiple pages", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: TEAMS_PAGE_SIZE }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
       const secondBatch: WebApiTeam[] = Array.from({ length: 3 }, (_, i) => ({
-        id: `team-${100 + i}`,
-        name: `Team ${100 + i}`,
+        id: `team-${TEAMS_PAGE_SIZE + i}`,
+        name: `Team ${TEAMS_PAGE_SIZE + i}`,
       })) as any;
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(103);
+      expect(result).toHaveLength(TEAMS_PAGE_SIZE + 3);
       expect(result[0].id).toBe("team-0");
-      expect(result[99].id).toBe("team-99");
-      expect(result[100].id).toBe("team-100");
-      expect(result[102].id).toBe("team-102");
+      expect(result[TEAMS_PAGE_SIZE - 1].id).toBe("team-4");
+      expect(result[TEAMS_PAGE_SIZE].id).toBe("team-5");
+      expect(result[TEAMS_PAGE_SIZE + 2].id).toBe("team-7");
     });
 
     it("should handle different project ids in pagination", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: TEAMS_PAGE_SIZE }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-100", name: "Team 100" } as any];
+      const secondBatch: WebApiTeam[] = [{ id: "team-5", name: "Team 5" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       await azureDevOpsCoreService.getAllTeams("project-xyz", true);
 
-      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-xyz", true, 100, 0);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-xyz", true, 100, 100);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-xyz", true, TEAMS_PAGE_SIZE, 0);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-xyz", true, TEAMS_PAGE_SIZE, TEAMS_PAGE_SIZE);
     });
   });
 });

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -169,7 +169,7 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(result).toEqual(mockMembers);
       expect(result).toHaveLength(2);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-123", "team-123", 10, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-123", "team-123", 100, 0);
     });
 
     it("should return null when members cannot be retrieved", async () => {
@@ -203,26 +203,26 @@ describe("AzureDevOpsCoreService", () => {
 
       await azureDevOpsCoreService.getMembers("project-abc", "team-xyz");
 
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-abc", "team-xyz", 10, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenCalledWith("project-abc", "team-xyz", 100, 0);
     });
 
     it("should fetch additional pages when the first page is full", async () => {
-      const firstPage: TeamMember[] = Array.from({ length: 10 }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
-      const secondPage: TeamMember[] = [{ identity: { displayName: "User 11" } } as any];
+      const firstPage: TeamMember[] = Array.from({ length: 100 }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
+      const secondPage: TeamMember[] = [{ identity: { displayName: "User 101" } } as any];
       mockGetTeamMembersWithExtendedProperties
         .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(secondPage);
 
       const result = await azureDevOpsCoreService.getMembers("project-abc", "team-xyz");
 
-      expect(result).toHaveLength(11);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(1, "project-abc", "team-xyz", 10, 0);
-      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(2, "project-abc", "team-xyz", 10, 10);
+      expect(result).toHaveLength(101);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(1, "project-abc", "team-xyz", 100, 0);
+      expect(mockGetTeamMembersWithExtendedProperties).toHaveBeenNthCalledWith(2, "project-abc", "team-xyz", 100, 100);
     });
   });
 
   describe("getAllTeams", () => {
-    it("should return all teams when less than 10 teams", async () => {
+    it("should return all teams when less than 100 teams", async () => {
       const mockTeams: WebApiTeam[] = [{ id: "team-1", name: "Team 1" } as any, { id: "team-2", name: "Team 2" } as any, { id: "team-3", name: "Team 3" } as any];
 
       mockGetTeams.mockResolvedValue(mockTeams);
@@ -231,48 +231,48 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(result).toEqual(mockTeams);
       expect(result).toHaveLength(3);
-      expect(mockGetTeams).toHaveBeenCalledWith("project-123", false, 10, 0);
+      expect(mockGetTeams).toHaveBeenCalledWith("project-123", false, 100, 0);
       expect(mockGetTeams).toHaveBeenCalledTimes(1);
     });
 
-    it("should paginate when there are exactly 10 teams", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
+    it("should paginate when there are exactly 100 teams", async () => {
+      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-10", name: "Team 10" } as any, { id: "team-11", name: "Team 11" } as any];
+      const secondBatch: WebApiTeam[] = [{ id: "team-100", name: "Team 100" } as any, { id: "team-101", name: "Team 101" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(12);
+      expect(result).toHaveLength(102);
       expect(mockGetTeams).toHaveBeenCalledTimes(2);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-123", false, 10, 0);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-123", false, 10, 10);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-123", false, 100, 0);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-123", false, 100, 100);
     });
 
     it("should handle multiple pagination rounds", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
-        id: `team-${10 + i}`,
-        name: `Team ${10 + i}`,
+      const secondBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
+        id: `team-${100 + i}`,
+        name: `Team ${100 + i}`,
       })) as any;
 
-      const thirdBatch: WebApiTeam[] = [{ id: "team-20", name: "Team 20" } as any];
+      const thirdBatch: WebApiTeam[] = [{ id: "team-200", name: "Team 200" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch).mockResolvedValueOnce(thirdBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(21);
+      expect(result).toHaveLength(201);
       expect(mockGetTeams).toHaveBeenCalledTimes(3);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(3, "project-123", false, 10, 20);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(3, "project-123", false, 100, 200);
     });
 
     it("should respect forCurrentUserOnly parameter", async () => {
@@ -282,7 +282,7 @@ describe("AzureDevOpsCoreService", () => {
 
       await azureDevOpsCoreService.getAllTeams("project-456", true);
 
-      expect(mockGetTeams).toHaveBeenCalledWith("project-456", true, 10, 0);
+      expect(mockGetTeams).toHaveBeenCalledWith("project-456", true, 100, 0);
     });
 
     it("should handle empty teams list", async () => {
@@ -296,41 +296,41 @@ describe("AzureDevOpsCoreService", () => {
     });
 
     it("should accumulate teams across multiple pages", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
       const secondBatch: WebApiTeam[] = Array.from({ length: 3 }, (_, i) => ({
-        id: `team-${10 + i}`,
-        name: `Team ${10 + i}`,
+        id: `team-${100 + i}`,
+        name: `Team ${100 + i}`,
       })) as any;
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       const result = await azureDevOpsCoreService.getAllTeams("project-123", false);
 
-      expect(result).toHaveLength(13);
+      expect(result).toHaveLength(103);
       expect(result[0].id).toBe("team-0");
-      expect(result[9].id).toBe("team-9");
-      expect(result[10].id).toBe("team-10");
-      expect(result[12].id).toBe("team-12");
+      expect(result[99].id).toBe("team-99");
+      expect(result[100].id).toBe("team-100");
+      expect(result[102].id).toBe("team-102");
     });
 
     it("should handle different project ids in pagination", async () => {
-      const firstBatch: WebApiTeam[] = Array.from({ length: 10 }, (_, i) => ({
+      const firstBatch: WebApiTeam[] = Array.from({ length: 100 }, (_, i) => ({
         id: `team-${i}`,
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-10", name: "Team 10" } as any];
+      const secondBatch: WebApiTeam[] = [{ id: "team-100", name: "Team 100" } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 
       await azureDevOpsCoreService.getAllTeams("project-xyz", true);
 
-      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-xyz", true, 10, 0);
-      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-xyz", true, 10, 10);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(1, "project-xyz", true, 100, 0);
+      expect(mockGetTeams).toHaveBeenNthCalledWith(2, "project-xyz", true, 100, 100);
     });
   });
 });

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -268,7 +268,7 @@ describe("AzureDevOpsCoreService", () => {
         name: `Team ${TEAMS_PAGE_SIZE + i}`,
       })) as any;
 
-      const thirdBatch: WebApiTeam[] = [{ id: "team-10", name: "Team 10" } as any];
+      const thirdBatch: WebApiTeam[] = [{ id: `team-${TEAMS_PAGE_SIZE * 2}`, name: `Team ${TEAMS_PAGE_SIZE * 2}` } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch).mockResolvedValueOnce(thirdBatch);
 

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -14,8 +14,8 @@ jest.mock("azure-devops-extension-api/Common", () => ({
 }));
 
 describe("AzureDevOpsCoreService", () => {
-  const MEMBERS_PAGE_SIZE = 5;
-  const TEAMS_PAGE_SIZE = 5;
+  const MEMBERS_PAGE_SIZE = 100;
+  const TEAMS_PAGE_SIZE = 100;
   let azureDevOpsCoreService: any;
 
   beforeEach(() => {
@@ -314,9 +314,9 @@ describe("AzureDevOpsCoreService", () => {
 
       expect(result).toHaveLength(TEAMS_PAGE_SIZE + 3);
       expect(result[0].id).toBe("team-0");
-      expect(result[TEAMS_PAGE_SIZE - 1].id).toBe("team-4");
-      expect(result[TEAMS_PAGE_SIZE].id).toBe("team-5");
-      expect(result[TEAMS_PAGE_SIZE + 2].id).toBe("team-7");
+      expect(result[TEAMS_PAGE_SIZE - 1].id).toBe(`team-${TEAMS_PAGE_SIZE - 1}`);
+      expect(result[TEAMS_PAGE_SIZE].id).toBe(`team-${TEAMS_PAGE_SIZE}`);
+      expect(result[TEAMS_PAGE_SIZE + 2].id).toBe(`team-${TEAMS_PAGE_SIZE + 2}`);
     });
 
     it("should handle different project ids in pagination", async () => {

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -210,8 +210,7 @@ describe("AzureDevOpsCoreService", () => {
 
     it("should fetch additional pages when the first page is full", async () => {
       const firstPage: TeamMember[] = Array.from({ length: MEMBERS_PAGE_SIZE }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
-      const secondPage: TeamMember[] = [{ identity: { displayName: "User 6" } } as any];
-      mockGetTeamMembersWithExtendedProperties
+      const secondPage: TeamMember[] = [{ identity: { displayName: "User 101" } } as any];
         .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(secondPage);
 

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -242,7 +242,10 @@ describe("AzureDevOpsCoreService", () => {
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-5", name: "Team 5" } as any, { id: "team-6", name: "Team 6" } as any];
+      const secondBatch: WebApiTeam[] = [
+        { id: `team-${TEAMS_PAGE_SIZE}`, name: `Team ${TEAMS_PAGE_SIZE}` } as any,
+        { id: `team-${TEAMS_PAGE_SIZE + 1}`, name: `Team ${TEAMS_PAGE_SIZE + 1}` } as any,
+      ];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -327,7 +327,9 @@ describe("AzureDevOpsCoreService", () => {
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [{ id: "team-5", name: "Team 5" } as any];
+      const secondBatch: WebApiTeam[] = [
+        { id: `team-${TEAMS_PAGE_SIZE}`, name: `Team ${TEAMS_PAGE_SIZE}` } as any,
+      ];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 

--- a/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
+++ b/src/frontend/dal/__tests__/azureDevOpsCoreService.test.tsx
@@ -210,7 +210,8 @@ describe("AzureDevOpsCoreService", () => {
 
     it("should fetch additional pages when the first page is full", async () => {
       const firstPage: TeamMember[] = Array.from({ length: MEMBERS_PAGE_SIZE }, (_, index) => ({ identity: { displayName: `User ${index + 1}` } } as any));
-      const secondPage: TeamMember[] = [{ identity: { displayName: "User 101" } } as any];
+      const secondPage: TeamMember[] = [{ identity: { displayName: `User ${MEMBERS_PAGE_SIZE + 1}` } } as any];
+      mockGetTeamMembersWithExtendedProperties
         .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(secondPage);
 
@@ -327,9 +328,7 @@ describe("AzureDevOpsCoreService", () => {
         name: `Team ${i}`,
       })) as any;
 
-      const secondBatch: WebApiTeam[] = [
-        { id: `team-${TEAMS_PAGE_SIZE}`, name: `Team ${TEAMS_PAGE_SIZE}` } as any,
-      ];
+      const secondBatch: WebApiTeam[] = [{ id: `team-${TEAMS_PAGE_SIZE}`, name: `Team ${TEAMS_PAGE_SIZE}` } as any];
 
       mockGetTeams.mockResolvedValueOnce(firstBatch).mockResolvedValueOnce(secondBatch);
 

--- a/src/frontend/dal/azureDevOpsCoreService.tsx
+++ b/src/frontend/dal/azureDevOpsCoreService.tsx
@@ -3,8 +3,8 @@ import { WebApiTeam } from "azure-devops-extension-api/Core";
 import { TeamMember } from "azure-devops-extension-api/WebApi";
 import { getClient } from "azure-devops-extension-api/Common";
 
-const MEMBERS_PAGE_SIZE = 100;
-const TEAMS_PAGE_SIZE = 100;
+const MEMBERS_PAGE_SIZE = 5;
+const TEAMS_PAGE_SIZE = 5;
 
 class AzureDevOpsCoreService {
   private _httpCoreClient: CoreRestClient;

--- a/src/frontend/dal/azureDevOpsCoreService.tsx
+++ b/src/frontend/dal/azureDevOpsCoreService.tsx
@@ -3,8 +3,8 @@ import { WebApiTeam } from "azure-devops-extension-api/Core";
 import { TeamMember } from "azure-devops-extension-api/WebApi";
 import { getClient } from "azure-devops-extension-api/Common";
 
-const MEMBERS_PAGE_SIZE = 10;
-const TEAMS_PAGE_SIZE = 10;
+const MEMBERS_PAGE_SIZE = 100;
+const TEAMS_PAGE_SIZE = 100;
 
 class AzureDevOpsCoreService {
   private _httpCoreClient: CoreRestClient;

--- a/src/frontend/dal/azureDevOpsCoreService.tsx
+++ b/src/frontend/dal/azureDevOpsCoreService.tsx
@@ -3,8 +3,8 @@ import { WebApiTeam } from "azure-devops-extension-api/Core";
 import { TeamMember } from "azure-devops-extension-api/WebApi";
 import { getClient } from "azure-devops-extension-api/Common";
 
-const MEMBERS_PAGE_SIZE = 5;
-const TEAMS_PAGE_SIZE = 5;
+const MEMBERS_PAGE_SIZE = 10;
+const TEAMS_PAGE_SIZE = 10;
 
 class AzureDevOpsCoreService {
   private _httpCoreClient: CoreRestClient;

--- a/src/frontend/dal/azureDevOpsCoreService.tsx
+++ b/src/frontend/dal/azureDevOpsCoreService.tsx
@@ -45,7 +45,22 @@ class AzureDevOpsCoreService {
    */
   public async getMembers(projectId: string, teamId: string): Promise<TeamMember[]> {
     try {
-      return await this._httpCoreClient.getTeamMembersWithExtendedProperties(projectId, teamId, 100, 0);
+      const allMembers: TeamMember[] = [];
+
+      const getMemberBatch = async (skip: number): Promise<void> => {
+        const memberBatch: TeamMember[] = await this._httpCoreClient.getTeamMembersWithExtendedProperties(projectId, teamId, 100, skip);
+
+        if (memberBatch.length > 0) {
+          allMembers.push(...memberBatch);
+        }
+
+        if (memberBatch.length === 100) {
+          await getMemberBatch(skip + 100);
+        }
+      };
+
+      await getMemberBatch(0);
+      return allMembers;
     } catch {
       return null;
     }

--- a/src/frontend/dal/azureDevOpsCoreService.tsx
+++ b/src/frontend/dal/azureDevOpsCoreService.tsx
@@ -46,7 +46,7 @@ class AzureDevOpsCoreService {
    * @param projectId The project ID.
    * @param teamId The team ID.
    */
-  public async getMembers(projectId: string, teamId: string): Promise<TeamMember[]> {
+  public async getMembers(projectId: string, teamId: string): Promise<TeamMember[] | null> {
     try {
       const allMembers: TeamMember[] = [];
 

--- a/src/frontend/dal/azureDevOpsCoreService.tsx
+++ b/src/frontend/dal/azureDevOpsCoreService.tsx
@@ -3,8 +3,8 @@ import { WebApiTeam } from "azure-devops-extension-api/Core";
 import { TeamMember } from "azure-devops-extension-api/WebApi";
 import { getClient } from "azure-devops-extension-api/Common";
 
-const MEMBERS_PAGE_SIZE = 5;
-const TEAMS_PAGE_SIZE = 5;
+const MEMBERS_PAGE_SIZE = 100;
+const TEAMS_PAGE_SIZE = 100;
 
 class AzureDevOpsCoreService {
   private _httpCoreClient: CoreRestClient;

--- a/src/frontend/dal/azureDevOpsCoreService.tsx
+++ b/src/frontend/dal/azureDevOpsCoreService.tsx
@@ -50,19 +50,18 @@ class AzureDevOpsCoreService {
     try {
       const allMembers: TeamMember[] = [];
 
-      const getMemberBatch = async (skip: number): Promise<void> => {
+      for (let skip = 0; ; skip += MEMBERS_PAGE_SIZE) {
         const memberBatch: TeamMember[] = await this._httpCoreClient.getTeamMembersWithExtendedProperties(projectId, teamId, MEMBERS_PAGE_SIZE, skip);
 
         if (memberBatch.length > 0) {
           allMembers.push(...memberBatch);
         }
 
-        if (memberBatch.length === MEMBERS_PAGE_SIZE) {
-          await getMemberBatch(skip + MEMBERS_PAGE_SIZE);
+        if (memberBatch.length < MEMBERS_PAGE_SIZE) {
+          break;
         }
-      };
+      }
 
-      await getMemberBatch(0);
       return allMembers;
     } catch {
       return null;
@@ -79,20 +78,17 @@ class AzureDevOpsCoreService {
 
     const _httpCoreClient: CoreRestClient = getClient(CoreRestClient);
 
-    const getTeamBatch = async (skip: number) => {
+    for (let skip = 0; ; skip += TEAMS_PAGE_SIZE) {
       const teamBatch: WebApiTeam[] = await _httpCoreClient.getTeams(projectId, forCurrentUserOnly, TEAMS_PAGE_SIZE, skip);
 
       if (teamBatch.length > 0) {
         allTeams.push(...teamBatch);
       }
 
-      if (teamBatch.length === TEAMS_PAGE_SIZE) {
-        await getTeamBatch(skip + TEAMS_PAGE_SIZE);
+      if (teamBatch.length < TEAMS_PAGE_SIZE) {
+        break;
       }
-      return;
-    };
-
-    await getTeamBatch(0);
+    }
 
     return allTeams;
   }

--- a/src/frontend/dal/azureDevOpsCoreService.tsx
+++ b/src/frontend/dal/azureDevOpsCoreService.tsx
@@ -3,6 +3,9 @@ import { WebApiTeam } from "azure-devops-extension-api/Core";
 import { TeamMember } from "azure-devops-extension-api/WebApi";
 import { getClient } from "azure-devops-extension-api/Common";
 
+const MEMBERS_PAGE_SIZE = 5;
+const TEAMS_PAGE_SIZE = 5;
+
 class AzureDevOpsCoreService {
   private _httpCoreClient: CoreRestClient;
 
@@ -48,14 +51,14 @@ class AzureDevOpsCoreService {
       const allMembers: TeamMember[] = [];
 
       const getMemberBatch = async (skip: number): Promise<void> => {
-        const memberBatch: TeamMember[] = await this._httpCoreClient.getTeamMembersWithExtendedProperties(projectId, teamId, 100, skip);
+        const memberBatch: TeamMember[] = await this._httpCoreClient.getTeamMembersWithExtendedProperties(projectId, teamId, MEMBERS_PAGE_SIZE, skip);
 
         if (memberBatch.length > 0) {
           allMembers.push(...memberBatch);
         }
 
-        if (memberBatch.length === 100) {
-          await getMemberBatch(skip + 100);
+        if (memberBatch.length === MEMBERS_PAGE_SIZE) {
+          await getMemberBatch(skip + MEMBERS_PAGE_SIZE);
         }
       };
 
@@ -77,14 +80,14 @@ class AzureDevOpsCoreService {
     const _httpCoreClient: CoreRestClient = getClient(CoreRestClient);
 
     const getTeamBatch = async (skip: number) => {
-      const teamBatch: WebApiTeam[] = await _httpCoreClient.getTeams(projectId, forCurrentUserOnly, 100, skip);
+      const teamBatch: WebApiTeam[] = await _httpCoreClient.getTeams(projectId, forCurrentUserOnly, TEAMS_PAGE_SIZE, skip);
 
       if (teamBatch.length > 0) {
         allTeams.push(...teamBatch);
       }
 
-      if (teamBatch.length === 100) {
-        await getTeamBatch(skip + 100);
+      if (teamBatch.length === TEAMS_PAGE_SIZE) {
+        await getTeamBatch(skip + TEAMS_PAGE_SIZE);
       }
       return;
     };

--- a/src/frontend/dal/azureDevOpsCoreService.tsx
+++ b/src/frontend/dal/azureDevOpsCoreService.tsx
@@ -76,10 +76,8 @@ class AzureDevOpsCoreService {
   public async getAllTeams(projectId: string, forCurrentUserOnly: boolean): Promise<WebApiTeam[]> {
     const allTeams: WebApiTeam[] = [];
 
-    const _httpCoreClient: CoreRestClient = getClient(CoreRestClient);
-
     for (let skip = 0; ; skip += TEAMS_PAGE_SIZE) {
-      const teamBatch: WebApiTeam[] = await _httpCoreClient.getTeams(projectId, forCurrentUserOnly, TEAMS_PAGE_SIZE, skip);
+      const teamBatch: WebApiTeam[] = await this._httpCoreClient.getTeams(projectId, forCurrentUserOnly, TEAMS_PAGE_SIZE, skip);
 
       if (teamBatch.length > 0) {
         allTeams.push(...teamBatch);

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -1545,6 +1545,14 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
 }
 
 .board-metadata-form {
+  &.board-metadata-form-permissions .permission-info-messages {
+    @apply grid gap-3 mb-3;
+
+    & .board-metadata-form-section-information {
+      @apply my-0;
+    }
+  }
+
   & hr {
     @apply border border-primary;
   }

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -659,7 +659,7 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
 }
 
 .board-metadata-form-permissions {
-  @apply h-full min-h-0 flex flex-col;
+  @apply flex-1 min-h-0 flex flex-col;
 }
 
 .board-metadata-form-permissions .board-metadata-form-board-settings {
@@ -1541,7 +1541,7 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
 }
 
 .feedback-board-metadata-form > #board-metadata-permissions-panel {
-  @apply min-h-0 overflow-hidden;
+  @apply flex min-h-0 flex-col overflow-hidden;
 }
 
 .board-metadata-form {


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #1715

## Description

Increases and prioritized permission retrival
1) always include board owner
2) always include users and teams with permission checked
3) always include current team and current team members associated with board
4) if board owner or team admin include up to 200 users and 100 teams based on selected my teams or all teams option

## Bug or Feature?

- [x] Bug fix
- [x] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated any relevant documentation accordingly.
- [x] I have added either the `docs updated` or `docs not needed` label to this PR.
- [x] If I used `docs updated`, I updated the relevant release-facing content, such as `CHANGELOG.md`, What's New, `README.md`, or `src/frontend/assets/PACKAGE-DESCRIPTION.md`.
  - [x] If I updated `CHANGELOG.md`, I included a link to this PR in that blurb.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

<!-- Do you have any screenshots or logs that would show off your fix? -->
