### PR TITLE
feat: prevent creation of empty feedback item on double click in FeedbackColumn

### DIFF
--- a/src/frontend/components/__tests__/feedbackColumn.test.tsx
+++ b/src/frontend/components/__tests__/feedbackColumn.test.tsx
@@ -1942,6 +1942,29 @@ describe("Feedback Column ", () => {
         expect(addFeedbackItems).toHaveBeenCalled();
       }
     });
+
+    test("does not create an empty feedback item when a card is double clicked", () => {
+      const addFeedbackItems = jest.fn();
+      const props = {
+        ...testColumnProps,
+        workflowPhase: WorkflowPhase.Collect,
+        addFeedbackItems,
+        columnItems: [] as IColumnItem[],
+      };
+
+      const { container } = render(<FeedbackColumn {...props} />);
+      const column = container.querySelector(".feedback-column") as HTMLElement;
+      const feedbackCard = document.createElement("div");
+      const editor = document.createElement("textarea");
+
+      feedbackCard.dataset.feedbackItemId = "existing-feedback-item";
+      feedbackCard.appendChild(editor);
+      column.appendChild(feedbackCard);
+
+      fireEvent.doubleClick(editor);
+
+      expect(addFeedbackItems).not.toHaveBeenCalled();
+    });
   });
 
   describe("ComponentWillUnmount cleanup", () => {

--- a/src/frontend/components/feedbackColumn.tsx
+++ b/src/frontend/components/feedbackColumn.tsx
@@ -303,6 +303,17 @@ const FeedbackColumn = forwardRef<FeedbackColumnHandle, FeedbackColumnProps>((pr
     addFeedbackItems(columnId, [feedbackItem], /*shouldBroadcast*/ false, /*newlyCreated*/ true, /*showAddedAnimation*/ false, /*shouldHaveFocus*/ false, /*hideFeedbackItems*/ false);
   }, [workflowPhase, currentColumnItems, boardId, columnId, isBoardAnonymous, addFeedbackItems]);
 
+  const handleColumnDoubleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if ((event.target as HTMLElement).closest("[data-feedback-item-id]")) {
+        return;
+      }
+
+      createEmptyFeedbackItem();
+    },
+    [createEmptyFeedbackItem],
+  );
+
   const openEditDialog = useCallback(() => {
     setColumnNotesDraft(columnNotes);
     editColumnNotesDialogRef.current!.showModal();
@@ -449,7 +460,7 @@ const FeedbackColumn = forwardRef<FeedbackColumnHandle, FeedbackColumnProps>((pr
   }, [currentColumnItems, getNavigableColumnItems, props, workflowPhase]);
 
   return (
-    <div ref={columnRef} className="feedback-column" role="region" aria-label={`${columnName} column with ${currentColumnItems.length} feedback items`} tabIndex={0} onDoubleClick={createEmptyFeedbackItem} onDrop={handleDropFeedbackItemOnColumnSpace} onDragOver={dragFeedbackItemOverColumn}>
+    <div ref={columnRef} className="feedback-column" role="region" aria-label={`${columnName} column with ${currentColumnItems.length} feedback items`} tabIndex={0} onDoubleClick={handleColumnDoubleClick} onDrop={handleDropFeedbackItemOnColumnSpace} onDragOver={dragFeedbackItemOverColumn}>
       <div className="feedback-column-header">
         <div className="feedback-column-title" aria-label={`${columnName} (${currentColumnItems.length} feedback items)`}>
           <div className="feedback-column-icon">{icon}</div>


### PR DESCRIPTION
Fixes #547 