### PR TITLE
Update changelog: missing user setting to toggle between show all and my teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,8 @@ From [GitHub PR #1832](https://github.com/microsoft/vsts-extension-retrospective
 
 ## v1.92.56
 
-* Introduced Admin Settings with an option to configure available work item types for "Add work item".
+* Introduced user setting with option to toggle between "Show all teams" and "Show my teams".
+* Introduced admin setting with an option to configure available work item types for "Add work item".
 * Set available work item types to default to Requirement Backlog types for both the Act tab and Focus mode.
 * Fixed Link existing work item in Focus mode so it stays in Focus mode instead of returning to Act tab.
 * Refined the "Add work item" selection to ensure the full work item list is visible on the Act tab and Focus mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ From [GitHub PR #1832](https://github.com/microsoft/vsts-extension-retrospective
 
 ## v1.92.56
 
-* Introduced user setting with option to toggle between "Show all teams" and "Show my teams".
+* Introduced user setting with an option to toggle between "Show all teams" and "Show my teams".
 * Introduced admin setting with an option to configure available work item types for "Add work item".
 * Set available work item types to default to Requirement Backlog types for both the Act tab and Focus mode.
 * Fixed Link existing work item in Focus mode so it stays in Focus mode instead of returning to Act tab.

--- a/src/frontend/components/whatsNewDialog.tsx
+++ b/src/frontend/components/whatsNewDialog.tsx
@@ -17,7 +17,7 @@ const WHATS_NEW_ITEMS = [
   "Fixed retrospective board links for Azure DevOps organizations.",
   "Added longer column titles.",
   "Added sort-direction indicators to History table.",
-  "Restricted editing of retrospective settings to the Board Owner and Team Admin.",
+  "Restricted editing of retrospective settings to the Board Owner or a Team Admin.",
   "Fixed the email summary Copy to clipboard action so it works reliably from the preview dialog.",
   "Extended permissions so team admins can also update column notes and edit or delete feedback cards.",
   "Improved hidden feedback behavior to display blurred feedback while announcing \"feedback blurred\".",

--- a/src/frontend/components/whatsNewDialog.tsx
+++ b/src/frontend/components/whatsNewDialog.tsx
@@ -6,7 +6,7 @@ interface IWhatsNewDialogProps {
   dialogRef: React.RefObject<HTMLDialogElement | null>;
 }
 
-const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.59, v1.92.58, v1.92.57, and v1.92.56 include:";
+const WHATS_NEW_HEADER_TEXT = "Highlights from releases v1.92.60, v1.92.59, v1.92.58, and v1.92.57 include:";
 
 const WHATS_NEW_ITEMS = [
   "Added a Move Everyone control so board managers can move all participants to the selected retrospective phase.",
@@ -17,14 +17,10 @@ const WHATS_NEW_ITEMS = [
   "Fixed retrospective board links for Azure DevOps organizations.",
   "Added longer column titles.",
   "Added sort-direction indicators to History table.",
-  "Added user settings to toggle between show all teams or my teams and to toggle between scrolling by board or by column.",
   "Restricted editing of retrospective settings to the Board Owner and Team Admin.",
   "Fixed the email summary Copy to clipboard action so it works reliably from the preview dialog.",
   "Extended permissions so team admins can also update column notes and edit or delete feedback cards.",
   "Improved hidden feedback behavior to display blurred feedback while announcing \"feedback blurred\".",
-  "Added team admin setting for configuring available work item types in \"Add work item\".",
-  "Defaulted add-work-item type options to Requirement Backlog types for the Act tab and Focus mode.",
-  "Adjusted the \"Add work item\" selection to ensure the full list of work item types is visible for the Act tab and Focus mode.",
 ];
 
 const WHATS_NEW_FOOTER_TEXT = "Refer to the Changelog for a complete history of updates.";


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): ADO Bug 4020

## Description

Changelog was missing reference to user setting which allows user to toggle between showing my teams (default) and showing all teams.

## Bug or Feature?

- [x] Bug fix
- [ ] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated any relevant documentation accordingly.
- [x] I have added either the `docs updated` or `docs not needed` label to this PR.
- [x] If I used `docs updated`, I updated the relevant release-facing content, such as `CHANGELOG.md`, What's New, `README.md`, or `src/frontend/assets/PACKAGE-DESCRIPTION.md`.
  - [ ] If I updated `CHANGELOG.md`, I included a link to this PR in that blurb.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

<!-- Do you have any screenshots or logs that would show off your fix? -->
