### PR TITLE
Refactor avatar logic so consistent and robust starting with simple initials fallback

### DIFF
--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -361,11 +361,11 @@ describe("avatar helpers", () => {
   });
 
   it("returns deterministic color for the same user seed", () => {
-    expect(getIdentityColor("David Hanson")).toBe(getIdentityColor("David Hanson"));
+    expect(getIdentityColor("aad.user-123", "David Hanson")).toBe(getIdentityColor("aad.user-123", "David Hanson"));
   });
 
   it("can return different colors for different users with same initials", () => {
-    expect(getIdentityColor("David Hanson")).not.toBe(getIdentityColor("Daniel Harding"));
+    expect(getIdentityColor("aad.user-123", "David Hanson")).not.toBe(getIdentityColor("msa.user-456", "David Hanson"));
   });
 });
 

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -5,7 +5,7 @@ import "@testing-library/jest-dom";
 import { mocked } from "jest-mock";
 import { TeamMember } from "azure-devops-extension-api/WebApi";
 import type { WebApiTeam } from "azure-devops-extension-api/Core";
-import { FeedbackBoardContainer, deduplicateTeamMembers, getAvatarImageUrl, getIdentityInitials } from "../feedbackBoardContainer";
+import { FeedbackBoardContainer, deduplicateTeamMembers, getAvatarImageUrl, getIdentityColor, getIdentityInitials } from "../feedbackBoardContainer";
 import { IFeedbackBoardDocument, IFeedbackBoardDocumentPermissions, IFeedbackItemDocument } from "../../interfaces/feedback";
 import { WorkflowPhase } from "../../interfaces/workItem";
 import { IdentityRef } from "azure-devops-extension-api/WebApi";
@@ -358,6 +358,14 @@ describe("avatar helpers", () => {
 
   it("returns two letters for single names", () => {
     expect(getIdentityInitials("David")).toBe("DA");
+  });
+
+  it("returns deterministic color for the same user seed", () => {
+    expect(getIdentityColor("user-123")).toBe(getIdentityColor("user-123"));
+  });
+
+  it("can return different colors for different users with same initials", () => {
+    expect(getIdentityColor("david-hanson-id")).not.toBe(getIdentityColor("daniel-harding-id"));
   });
 });
 

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -353,19 +353,19 @@ describe("avatar helpers", () => {
   });
 
   it("returns initials from first and last names", () => {
-    expect(getIdentityInitials("David Hanson")).toBe("DH");
+    expect(getIdentityInitials("Jane Doe")).toBe("JD");
   });
 
   it("returns two letters for single names", () => {
-    expect(getIdentityInitials("David")).toBe("DA");
+    expect(getIdentityInitials("John")).toBe("JO");
   });
 
   it("returns deterministic color for the same user seed", () => {
-    expect(getIdentityColor("aad.user-123", "David Hanson")).toBe(getIdentityColor("aad.user-123", "David Hanson"));
+    expect(getIdentityColor("aad.user-123", "Jane Doe")).toBe(getIdentityColor("aad.user-123", "Jane Doe"));
   });
 
-  it("can return different colors for different users with same initials", () => {
-    expect(getIdentityColor("aad.user-123", "David Hanson")).not.toBe(getIdentityColor("msa.user-456", "David Hanson"));
+  it("can return different colors for different users", () => {
+    expect(getIdentityColor("aad.user-123", "Jane Doe")).not.toBe(getIdentityColor("msa.user-456", "John Smith"));
   });
 });
 

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -5,7 +5,7 @@ import "@testing-library/jest-dom";
 import { mocked } from "jest-mock";
 import { TeamMember } from "azure-devops-extension-api/WebApi";
 import type { WebApiTeam } from "azure-devops-extension-api/Core";
-import { FeedbackBoardContainer, deduplicateTeamMembers } from "../feedbackBoardContainer";
+import { FeedbackBoardContainer, deduplicateTeamMembers, getAvatarImageUrl, getIdentityInitials } from "../feedbackBoardContainer";
 import { IFeedbackBoardDocument, IFeedbackBoardDocumentPermissions, IFeedbackItemDocument } from "../../interfaces/feedback";
 import { WorkflowPhase } from "../../interfaces/workItem";
 import { IdentityRef } from "azure-devops-extension-api/WebApi";
@@ -335,6 +335,29 @@ describe("deduplicateTeamMembers", () => {
   it("handles empty array", () => {
     const deduped = deduplicateTeamMembers([]);
     expect(deduped).toHaveLength(0);
+  });
+});
+
+describe("avatar helpers", () => {
+  it("prefers avatar link href when available", () => {
+    const imageUrl = getAvatarImageUrl({
+      imageUrl: "https://example.com/image-url",
+      _links: { avatar: { href: "https://example.com/avatar-href" } },
+    });
+
+    expect(imageUrl).toBe("https://example.com/avatar-href");
+  });
+
+  it("falls back to imageUrl when avatar link is not present", () => {
+    expect(getAvatarImageUrl({ imageUrl: "https://example.com/image-url" })).toBe("https://example.com/image-url");
+  });
+
+  it("returns initials from first and last names", () => {
+    expect(getIdentityInitials("David Hanson")).toBe("DH");
+  });
+
+  it("returns two letters for single names", () => {
+    expect(getIdentityInitials("David")).toBe("DA");
   });
 });
 

--- a/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -361,11 +361,11 @@ describe("avatar helpers", () => {
   });
 
   it("returns deterministic color for the same user seed", () => {
-    expect(getIdentityColor("user-123")).toBe(getIdentityColor("user-123"));
+    expect(getIdentityColor("David Hanson")).toBe(getIdentityColor("David Hanson"));
   });
 
   it("can return different colors for different users with same initials", () => {
-    expect(getIdentityColor("david-hanson-id")).not.toBe(getIdentityColor("daniel-harding-id"));
+    expect(getIdentityColor("David Hanson")).not.toBe(getIdentityColor("Daniel Harding"));
   });
 });
 

--- a/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
+++ b/src/frontend/components/__tests__/feedbackBoardMetadataFormPermissions.test.tsx
@@ -841,16 +841,17 @@ describe("Board Metadata Form Permissions", () => {
       expect(teamIcon).toBeInTheDocument();
     });
 
-    it("should render profile image for member type options", () => {
+    it("should render initials fallback for member type options", () => {
       const props = makeProps({
         permissions: { Teams: [], Members: [] },
         permissionOptions: [{ id: "user1", name: "User One", uniqueName: "user1@example.com", type: "member", thumbnailUrl: "https://example.com/avatar.jpg" }],
       });
 
       const { container } = render(<FeedbackBoardMetadataFormPermissions {...props} />);
-      const memberImage = container.querySelector('.permission-image[src="https://example.com/avatar.jpg"]');
+      const memberFallback = container.querySelector(".permission-image .avatar-fallback");
 
-      expect(memberImage).toBeInTheDocument();
+      expect(memberFallback).toBeInTheDocument();
+      expect(memberFallback).toHaveTextContent("UO");
     });
   });
 

--- a/src/frontend/components/__tests__/feedbackItem.test.tsx
+++ b/src/frontend/components/__tests__/feedbackItem.test.tsx
@@ -7545,7 +7545,7 @@ describe("Feedback Item", () => {
       expect(container.querySelector(".anonymous-created-date")).toBeInTheDocument();
     });
 
-    test("renders DocumentCardActivity when createdBy is provided", async () => {
+    test("renders shared avatar activity when createdBy is provided", async () => {
       const mockItem: IFeedbackItemDocument = {
         id: "non-anon-item",
         boardId: testBoardId,
@@ -7615,8 +7615,7 @@ describe("Feedback Item", () => {
         expect(itemDataService.getFeedbackItem).toHaveBeenCalled();
       });
 
-      // Check for ms-DocumentCardActivity class which is used when createdBy is provided
-      expect(container.querySelector(".ms-DocumentCardActivity")).toBeInTheDocument();
+      expect(container.querySelector(".feedback-item-activity")).toBeInTheDocument();
     });
   });
 

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -2813,7 +2813,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
               <div className="retro-summary-section-header">{t("feedback_board_basic_settings")}</div>
               <div id="retro-summary-created-date">{t("feedback_board_created_date", { date: formatDate(new Date(state.currentBoard.createdDate), { year: "numeric", month: "short", day: "numeric" }) })}</div>
               <div id="retro-summary-created-by">
-                {t("feedback_board_created_by")} <IdentityAvatar className="summary-avatar" name={state.currentBoard?.createdBy.displayName} imageUrl={getAvatarImageUrl(state.currentBoard?.createdBy)} forceInitialsFallback={FORCE_RETRO_SUMMARY_INITIALS_FALLBACK} /> {state.currentBoard?.createdBy.displayName}{" "}
+                {t("feedback_board_created_by")} <IdentityAvatar className="summary-avatar" name={state.currentBoard?.createdBy.displayName} imageUrl={getAvatarImageUrl(state.currentBoard?.createdBy)} colorSeed={state.currentBoard?.createdBy?.id} forceInitialsFallback={FORCE_RETRO_SUMMARY_INITIALS_FALLBACK} /> {state.currentBoard?.createdBy.displayName}{" "}
               </div>
             </section>
             <section className="retro-summary-section">
@@ -2824,7 +2824,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
                 <div className="retro-summary-contributors-section">
                   {state.contributors.map(contributor => (
                     <div key={contributor.id} className="retro-summary-contributor">
-                      <IdentityAvatar className="summary-avatar" name={contributor.name} imageUrl={contributor.imageUrl} forceInitialsFallback={FORCE_RETRO_SUMMARY_INITIALS_FALLBACK} /> {contributor.name}
+                      <IdentityAvatar className="summary-avatar" name={contributor.name} imageUrl={contributor.imageUrl} colorSeed={contributor.id} forceInitialsFallback={FORCE_RETRO_SUMMARY_INITIALS_FALLBACK} /> {contributor.name}
                     </div>
                   ))}
                 </div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -49,6 +49,56 @@ import { canCurrentUserManageBoard } from "../utilities/boardAccessHelper";
 type ScrollMode = "column" | "board";
 const SCROLL_MODE_SETTING_KEY = "lastScrollMode";
 const BOARD_TIMER_DURATION_OPTIONS = Array.from({ length: 20 }, (_, index) => index + 1);
+const FORCE_RETRO_SUMMARY_INITIALS_FALLBACK = true;
+
+type IdentityAvatarReference = {
+  displayName?: string;
+  imageUrl?: string;
+  _links?: {
+    avatar?: {
+      href?: string;
+    };
+  };
+};
+
+export const getAvatarImageUrl = (identity?: IdentityAvatarReference | null): string | undefined => {
+  return identity?._links?.avatar?.href || identity?.imageUrl || undefined;
+};
+
+export const getIdentityInitials = (name?: string): string => {
+  if (!name) {
+    return "?";
+  }
+
+  const tokens = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (!tokens.length) {
+    return "?";
+  }
+
+  if (tokens.length === 1) {
+    return tokens[0].slice(0, 2).toUpperCase();
+  }
+
+  return `${tokens[0][0]}${tokens[1][0]}`.toUpperCase();
+};
+
+function RetroSummaryAvatar({ name, imageUrl }: { name?: string; imageUrl?: string }) {
+  const [showImage, setShowImage] = React.useState(!FORCE_RETRO_SUMMARY_INITIALS_FALLBACK && Boolean(imageUrl));
+
+  React.useEffect(() => {
+    setShowImage(!FORCE_RETRO_SUMMARY_INITIALS_FALLBACK && Boolean(imageUrl));
+  }, [imageUrl]);
+
+  return (
+    <span className="summary-avatar" aria-label={name || "Unknown user"}>
+      {showImage && imageUrl ? <img className="avatar" src={imageUrl} alt={name} onError={() => setShowImage(false)} /> : <span className="avatar-fallback">{getIdentityInitials(name)}</span>}
+    </span>
+  );
+}
 
 export interface FeedbackBoardContainerState {
   boards: IFeedbackBoardDocument[];
@@ -89,7 +139,7 @@ export interface FeedbackBoardContainerState {
   isDropIssueInEdgeMessageBarVisible: boolean;
   allowCrossColumnGroups: boolean;
   feedbackItems: IFeedbackItemDocument[];
-  contributors: { id: string; name: string; imageUrl: string }[];
+  contributors: { id: string; name: string; imageUrl?: string }[];
   effectivenessMeasurementSummary: { questionId: number; question: string; average: number; teamAssessmentQuestion?: ITeamAssessmentQuestion }[];
   effectivenessMeasurementChartData: { questionId: number; red: number; yellow: number; green: number; teamAssessmentQuestion?: ITeamAssessmentQuestion }[];
   teamEffectivenessMeasurementAverageVisibilityClassName: string;
@@ -734,7 +784,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
 
       const contributors = feedbackItems
         .map(e => {
-          return { id: e.userIdRef, name: e?.createdBy?.displayName, imageUrl: e?.createdBy?.imageUrl };
+          return { id: e.userIdRef, name: e?.createdBy?.displayName, imageUrl: getAvatarImageUrl(e?.createdBy) };
         })
         .filter((v, i, a) => a.indexOf(v) === i);
 
@@ -2809,7 +2859,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
               <div className="retro-summary-section-header">{t("feedback_board_basic_settings")}</div>
               <div id="retro-summary-created-date">{t("feedback_board_created_date", { date: formatDate(new Date(state.currentBoard.createdDate), { year: "numeric", month: "short", day: "numeric" }) })}</div>
               <div id="retro-summary-created-by">
-                {t("feedback_board_created_by")} <img className="avatar" src={state.currentBoard?.createdBy.imageUrl} alt={state.currentBoard?.createdBy.displayName} /> {state.currentBoard?.createdBy.displayName}{" "}
+                {t("feedback_board_created_by")} <RetroSummaryAvatar name={state.currentBoard?.createdBy.displayName} imageUrl={getAvatarImageUrl(state.currentBoard?.createdBy)} /> {state.currentBoard?.createdBy.displayName}{" "}
               </div>
             </section>
             <section className="retro-summary-section">
@@ -2820,7 +2870,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
                 <div className="retro-summary-contributors-section">
                   {state.contributors.map(contributor => (
                     <div key={contributor.id} className="retro-summary-contributor">
-                      <img className="avatar" src={contributor.imageUrl} alt={contributor.name} /> {contributor.name}
+                      <RetroSummaryAvatar name={contributor.name} imageUrl={contributor.imageUrl} /> {contributor.name}
                     </div>
                   ))}
                 </div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -50,6 +50,7 @@ type ScrollMode = "column" | "board";
 const SCROLL_MODE_SETTING_KEY = "lastScrollMode";
 const BOARD_TIMER_DURATION_OPTIONS = Array.from({ length: 20 }, (_, index) => index + 1);
 const FORCE_RETRO_SUMMARY_INITIALS_FALLBACK = true;
+const AVATAR_FALLBACK_COLORS = ["#0078d4", "#d83b01", "#5c2d91", "#107c10", "#b146c2", "#c19c00", "#005a9e", "#ca5010"];
 
 type IdentityAvatarReference = {
   displayName?: string;
@@ -86,8 +87,22 @@ export const getIdentityInitials = (name?: string): string => {
   return `${tokens[0][0]}${tokens[1][0]}`.toUpperCase();
 };
 
-function RetroSummaryAvatar({ name, imageUrl }: { name?: string; imageUrl?: string }) {
+export const getIdentityColor = (seed?: string): string => {
+  if (!seed) {
+    return AVATAR_FALLBACK_COLORS[0];
+  }
+
+  let hash = 0;
+  for (let index = 0; index < seed.length; index++) {
+    hash = (hash * 31 + seed.charCodeAt(index)) >>> 0;
+  }
+
+  return AVATAR_FALLBACK_COLORS[hash % AVATAR_FALLBACK_COLORS.length];
+};
+
+function RetroSummaryAvatar({ name, imageUrl, colorSeed }: { name?: string; imageUrl?: string; colorSeed?: string }) {
   const [showImage, setShowImage] = React.useState(!FORCE_RETRO_SUMMARY_INITIALS_FALLBACK && Boolean(imageUrl));
+  const fallbackColor = React.useMemo(() => getIdentityColor(colorSeed || name), [colorSeed, name]);
 
   React.useEffect(() => {
     setShowImage(!FORCE_RETRO_SUMMARY_INITIALS_FALLBACK && Boolean(imageUrl));
@@ -95,7 +110,7 @@ function RetroSummaryAvatar({ name, imageUrl }: { name?: string; imageUrl?: stri
 
   return (
     <span className="summary-avatar" aria-label={name || "Unknown user"}>
-      {showImage && imageUrl ? <img className="avatar" src={imageUrl} alt={name} onError={() => setShowImage(false)} /> : <span className="avatar-fallback">{getIdentityInitials(name)}</span>}
+      {showImage && imageUrl ? <img className="avatar" src={imageUrl} alt={name} onError={() => setShowImage(false)} /> : <span className="avatar-fallback" style={{ backgroundColor: fallbackColor }}>{getIdentityInitials(name)}</span>}
     </span>
   );
 }
@@ -2859,7 +2874,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
               <div className="retro-summary-section-header">{t("feedback_board_basic_settings")}</div>
               <div id="retro-summary-created-date">{t("feedback_board_created_date", { date: formatDate(new Date(state.currentBoard.createdDate), { year: "numeric", month: "short", day: "numeric" }) })}</div>
               <div id="retro-summary-created-by">
-                {t("feedback_board_created_by")} <RetroSummaryAvatar name={state.currentBoard?.createdBy.displayName} imageUrl={getAvatarImageUrl(state.currentBoard?.createdBy)} /> {state.currentBoard?.createdBy.displayName}{" "}
+                {t("feedback_board_created_by")} <RetroSummaryAvatar name={state.currentBoard?.createdBy.displayName} imageUrl={getAvatarImageUrl(state.currentBoard?.createdBy)} colorSeed={state.currentBoard?.createdBy?.id} /> {state.currentBoard?.createdBy.displayName}{" "}
               </div>
             </section>
             <section className="retro-summary-section">
@@ -2870,7 +2885,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
                 <div className="retro-summary-contributors-section">
                   {state.contributors.map(contributor => (
                     <div key={contributor.id} className="retro-summary-contributor">
-                      <RetroSummaryAvatar name={contributor.name} imageUrl={contributor.imageUrl} /> {contributor.name}
+                      <RetroSummaryAvatar name={contributor.name} imageUrl={contributor.imageUrl} colorSeed={contributor.id} /> {contributor.name}
                     </div>
                   ))}
                 </div>

--- a/src/frontend/components/feedbackBoardContainer.tsx
+++ b/src/frontend/components/feedbackBoardContainer.tsx
@@ -45,75 +45,14 @@ import { TeamAssessmentHistoryChart } from "./teamAssessmentHistoryChart";
 import { workService } from "../dal/azureDevOpsWorkService";
 import { useDelayedTooltip } from "../utilities/useDelayedTooltip";
 import { canCurrentUserManageBoard } from "../utilities/boardAccessHelper";
+import IdentityAvatar from "./identityAvatar";
+import { getAvatarImageUrl, getIdentityColor, getIdentityInitials } from "../utilities/avatarFallbackHelper";
 
 type ScrollMode = "column" | "board";
 const SCROLL_MODE_SETTING_KEY = "lastScrollMode";
 const BOARD_TIMER_DURATION_OPTIONS = Array.from({ length: 20 }, (_, index) => index + 1);
 const FORCE_RETRO_SUMMARY_INITIALS_FALLBACK = true;
-const AVATAR_FALLBACK_COLORS = ["#0078d4", "#d83b01", "#5c2d91", "#107c10", "#b146c2", "#c19c00", "#005a9e", "#ca5010"];
-
-type IdentityAvatarReference = {
-  displayName?: string;
-  imageUrl?: string;
-  _links?: {
-    avatar?: {
-      href?: string;
-    };
-  };
-};
-
-export const getAvatarImageUrl = (identity?: IdentityAvatarReference | null): string | undefined => {
-  return identity?._links?.avatar?.href || identity?.imageUrl || undefined;
-};
-
-export const getIdentityInitials = (name?: string): string => {
-  if (!name) {
-    return "?";
-  }
-
-  const tokens = name
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean);
-
-  if (!tokens.length) {
-    return "?";
-  }
-
-  if (tokens.length === 1) {
-    return tokens[0].slice(0, 2).toUpperCase();
-  }
-
-  return `${tokens[0][0]}${tokens[1][0]}`.toUpperCase();
-};
-
-export const getIdentityColor = (seed?: string): string => {
-  if (!seed) {
-    return AVATAR_FALLBACK_COLORS[0];
-  }
-
-  let hash = 0;
-  for (let index = 0; index < seed.length; index++) {
-    hash = (hash * 31 + seed.charCodeAt(index)) >>> 0;
-  }
-
-  return AVATAR_FALLBACK_COLORS[hash % AVATAR_FALLBACK_COLORS.length];
-};
-
-function RetroSummaryAvatar({ name, imageUrl, colorSeed }: { name?: string; imageUrl?: string; colorSeed?: string }) {
-  const [showImage, setShowImage] = React.useState(!FORCE_RETRO_SUMMARY_INITIALS_FALLBACK && Boolean(imageUrl));
-  const fallbackColor = React.useMemo(() => getIdentityColor(colorSeed || name), [colorSeed, name]);
-
-  React.useEffect(() => {
-    setShowImage(!FORCE_RETRO_SUMMARY_INITIALS_FALLBACK && Boolean(imageUrl));
-  }, [imageUrl]);
-
-  return (
-    <span className="summary-avatar" aria-label={name || "Unknown user"}>
-      {showImage && imageUrl ? <img className="avatar" src={imageUrl} alt={name} onError={() => setShowImage(false)} /> : <span className="avatar-fallback" style={{ backgroundColor: fallbackColor }}>{getIdentityInitials(name)}</span>}
-    </span>
-  );
-}
+export { getAvatarImageUrl, getIdentityColor, getIdentityInitials };
 
 export interface FeedbackBoardContainerState {
   boards: IFeedbackBoardDocument[];
@@ -2874,7 +2813,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
               <div className="retro-summary-section-header">{t("feedback_board_basic_settings")}</div>
               <div id="retro-summary-created-date">{t("feedback_board_created_date", { date: formatDate(new Date(state.currentBoard.createdDate), { year: "numeric", month: "short", day: "numeric" }) })}</div>
               <div id="retro-summary-created-by">
-                {t("feedback_board_created_by")} <RetroSummaryAvatar name={state.currentBoard?.createdBy.displayName} imageUrl={getAvatarImageUrl(state.currentBoard?.createdBy)} colorSeed={state.currentBoard?.createdBy?.id} /> {state.currentBoard?.createdBy.displayName}{" "}
+                {t("feedback_board_created_by")} <IdentityAvatar className="summary-avatar" name={state.currentBoard?.createdBy.displayName} imageUrl={getAvatarImageUrl(state.currentBoard?.createdBy)} forceInitialsFallback={FORCE_RETRO_SUMMARY_INITIALS_FALLBACK} /> {state.currentBoard?.createdBy.displayName}{" "}
               </div>
             </section>
             <section className="retro-summary-section">
@@ -2885,7 +2824,7 @@ export function FeedbackBoardContainer({ isHostedAzureDevOps, projectId }: { isH
                 <div className="retro-summary-contributors-section">
                   {state.contributors.map(contributor => (
                     <div key={contributor.id} className="retro-summary-contributor">
-                      <RetroSummaryAvatar name={contributor.name} imageUrl={contributor.imageUrl} colorSeed={contributor.id} /> {contributor.name}
+                      <IdentityAvatar className="summary-avatar" name={contributor.name} imageUrl={contributor.imageUrl} forceInitialsFallback={FORCE_RETRO_SUMMARY_INITIALS_FALLBACK} /> {contributor.name}
                     </div>
                   ))}
                 </div>

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -214,7 +214,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
       return <PeopleIcon />;
     }
 
-    return <IdentityAvatar className="permission-image" name={props.option.name} imageUrl={props.option.thumbnailUrl} forceInitialsFallback={true} />;
+    return <IdentityAvatar className="permission-image" name={props.option.name} imageUrl={props.option.thumbnailUrl} colorSeed={props.option.id || props.option.uniqueName} forceInitialsFallback={true} />;
   };
 
   useEffect(() => {

--- a/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
+++ b/src/frontend/components/feedbackBoardMetadataFormPermissions.tsx
@@ -3,6 +3,7 @@ import { IFeedbackBoardDocument, IFeedbackBoardDocumentPermissions } from "../in
 import { useTrackMetric } from "@microsoft/applicationinsights-react-js";
 import { reactPlugin } from "../utilities/telemetryClient";
 import { getIconElement, PeopleIcon } from "./icons";
+import IdentityAvatar from "./identityAvatar";
 
 export interface IFeedbackBoardMetadataFormPermissionsProps {
   board: IFeedbackBoardDocument;
@@ -213,7 +214,7 @@ function FeedbackBoardMetadataFormPermissions(props: Readonly<IFeedbackBoardMeta
       return <PeopleIcon />;
     }
 
-    return <img className="permission-image" src={props.option.thumbnailUrl} alt={`Permission for ${props.option.name}`} />;
+    return <IdentityAvatar className="permission-image" name={props.option.name} imageUrl={props.option.thumbnailUrl} forceInitialsFallback={true} />;
   };
 
   useEffect(() => {

--- a/src/frontend/components/feedbackItem.tsx
+++ b/src/frontend/components/feedbackItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo, forwardRef, useImperativeHandle } from "react";
-import { DocumentCard, DocumentCardActivity } from "@fluentui/react/lib/DocumentCard";
+import { DocumentCard } from "@fluentui/react/lib/DocumentCard";
 import { SearchBox } from "@fluentui/react/lib/SearchBox";
 import { useTrackMetric } from "@microsoft/applicationinsights-react-js";
 import { WorkItem, WorkItemType } from "azure-devops-extension-api/WorkItemTracking/WorkItemTracking";
@@ -20,6 +20,7 @@ import { appInsights, reactPlugin, TelemetryEvents } from "../utilities/telemetr
 import { isAnyModalDialogOpen } from "../utilities/dialogHelper";
 import { getIconElement, MoreVerticalIcon } from "./icons";
 import { t } from "../utilities/localization";
+import IdentityAvatar from "./identityAvatar";
 
 export interface IFeedbackItemColumnContext {
   registerItemRef?: (itemId: string, element: HTMLElement | null) => void;
@@ -553,7 +554,15 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
       return <div className="anonymous-created-date">{formattedCreatedDate}</div>;
     }
 
-    return <DocumentCardActivity activity={formattedCreatedDate} people={[{ name: props.createdBy, profileImageSrc: props.createdByProfileImage }]} />;
+    return (
+      <div className="feedback-item-activity" aria-label={`Created by ${props.createdBy}`}>
+        <IdentityAvatar className="feedback-item-activity-avatar" name={props.createdBy} imageUrl={props.createdByProfileImage} forceInitialsFallback={true} />
+        <div className="feedback-item-activity-details">
+          <div className="feedback-item-activity-author">{props.createdBy}</div>
+          <div className="feedback-item-activity-time">{formattedCreatedDate}</div>
+        </div>
+      </div>
+    );
   }, [props.createdBy, props.createdByProfileImage, props.createdDate]);
 
   const deleteFeedbackItem = useCallback(() => {

--- a/src/frontend/components/feedbackItem.tsx
+++ b/src/frontend/components/feedbackItem.tsx
@@ -556,7 +556,7 @@ const FeedbackItem = forwardRef<FeedbackItemHandle, IFeedbackItemProps>((props, 
 
     return (
       <div className="feedback-item-activity" aria-label={`Created by ${props.createdBy}`}>
-        <IdentityAvatar className="feedback-item-activity-avatar" name={props.createdBy} imageUrl={props.createdByProfileImage} forceInitialsFallback={true} />
+        <IdentityAvatar className="feedback-item-activity-avatar" name={props.createdBy} imageUrl={props.createdByProfileImage} colorSeed={props.userIdRef} forceInitialsFallback={true} />
         <div className="feedback-item-activity-details">
           <div className="feedback-item-activity-author">{props.createdBy}</div>
           <div className="feedback-item-activity-time">{formattedCreatedDate}</div>

--- a/src/frontend/components/identityAvatar.tsx
+++ b/src/frontend/components/identityAvatar.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import { getIdentityColor, getIdentityInitials } from "../utilities/avatarFallbackHelper";
+
+type IdentityAvatarProps = {
+  name?: string;
+  imageUrl?: string;
+  forceInitialsFallback?: boolean;
+  className?: string;
+};
+
+export default function IdentityAvatar({ name, imageUrl, forceInitialsFallback = true, className = "" }: IdentityAvatarProps) {
+  const [showImage, setShowImage] = React.useState(!forceInitialsFallback && Boolean(imageUrl));
+  const fallbackColor = React.useMemo(() => getIdentityColor(name), [name]);
+
+  React.useEffect(() => {
+    setShowImage(!forceInitialsFallback && Boolean(imageUrl));
+  }, [forceInitialsFallback, imageUrl]);
+
+  const mergedClassName = ["identity-avatar", className].filter(Boolean).join(" ");
+
+  return (
+    <span className={mergedClassName} aria-label={name || "Unknown user"}>
+      {showImage && imageUrl ? <img className="avatar" src={imageUrl} alt={name} onError={() => setShowImage(false)} /> : <span className="avatar-fallback" style={{ backgroundColor: fallbackColor }}>{getIdentityInitials(name)}</span>}
+    </span>
+  );
+}

--- a/src/frontend/components/identityAvatar.tsx
+++ b/src/frontend/components/identityAvatar.tsx
@@ -5,13 +5,14 @@ import { getIdentityColor, getIdentityInitials } from "../utilities/avatarFallba
 type IdentityAvatarProps = {
   name?: string;
   imageUrl?: string;
+  colorSeed?: string;
   forceInitialsFallback?: boolean;
   className?: string;
 };
 
-export default function IdentityAvatar({ name, imageUrl, forceInitialsFallback = true, className = "" }: IdentityAvatarProps) {
+export default function IdentityAvatar({ name, imageUrl, colorSeed, forceInitialsFallback = true, className = "" }: IdentityAvatarProps) {
   const [showImage, setShowImage] = React.useState(!forceInitialsFallback && Boolean(imageUrl));
-  const fallbackColor = React.useMemo(() => getIdentityColor(name), [name]);
+  const fallbackColor = React.useMemo(() => getIdentityColor(colorSeed, name), [colorSeed, name]);
 
   React.useEffect(() => {
     setShowImage(!forceInitialsFallback && Boolean(imageUrl));

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -1474,7 +1474,7 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
   width: 1.5rem;
   height: 1.5rem;
   font-size: 0.75rem;
-  background-color: #c75b12;
+  background-color: var(--color-primary);
 }
 
 .retro-summary-dialog .retro-summary-effectiveness-scores {

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -1459,6 +1459,24 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
   @apply h-6 rounded-full align-middle -mt-1.5 inline;
 }
 
+.retro-summary-dialog .summary-avatar {
+  @apply inline-flex items-center justify-center align-middle -mt-1.5;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.retro-summary-dialog .summary-avatar .avatar {
+  @apply h-6 w-6 rounded-full;
+}
+
+.retro-summary-dialog .summary-avatar .avatar-fallback {
+  @apply inline-flex items-center justify-center rounded-full text-white font-semibold;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: 0.75rem;
+  background-color: #c75b12;
+}
+
 .retro-summary-dialog .retro-summary-effectiveness-scores {
   @apply clear-both relative min-w-25 min-h-25 p-0 flex flex-col items-center;
 }

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -692,6 +692,11 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
 
         & .permission-image {
           @apply w-11 min-w-11 max-w-11 h-11 rounded-full flex items-center justify-center text-(--text-primary-color) bg-(--background-color);
+
+          & .avatar,
+          & .avatar-fallback {
+            @apply w-11 h-11;
+          }
         }
       }
 
@@ -2228,6 +2233,14 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
 .feedback-item-group .feedback-item-activity .feedback-item-activity-avatar,
 .feedbackItemGroupItem .feedback-item-activity .feedback-item-activity-avatar {
   @apply shrink-0;
+
+  width: 2rem;
+  height: 2rem;
+
+  & .avatar,
+  & .avatar-fallback {
+    @apply w-8 h-8;
+  }
 }
 
 .feedbackItem .feedback-item-activity .feedback-item-activity-details,

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -1459,22 +1459,25 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
   @apply h-6 rounded-full align-middle -mt-1.5 inline;
 }
 
-.retro-summary-dialog .summary-avatar {
-  @apply inline-flex items-center justify-center align-middle -mt-1.5;
+.identity-avatar {
+  @apply inline-flex items-center justify-center align-middle;
   width: 1.5rem;
   height: 1.5rem;
 }
 
-.retro-summary-dialog .summary-avatar .avatar {
+.identity-avatar .avatar {
   @apply h-6 w-6 rounded-full;
 }
 
-.retro-summary-dialog .summary-avatar .avatar-fallback {
+.identity-avatar .avatar-fallback {
   @apply inline-flex items-center justify-center rounded-full text-white font-semibold;
   width: 1.5rem;
   height: 1.5rem;
   font-size: 0.75rem;
-  background-color: var(--color-primary);
+}
+
+.retro-summary-dialog .summary-avatar {
+  @apply -mt-1.5;
 }
 
 .retro-summary-dialog .retro-summary-effectiveness-scores {
@@ -2213,6 +2216,33 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
 .feedback-item-group .mainItemCard .card-integral-part .card-header,
 .feedbackItemGroupItem .groupedItemCard .card-integral-part .card-header {
   @apply inline-flex items-center justify-end gap-2 w-full h-8 mb-2.5 text-(--text-secondary-color);
+}
+
+.feedbackItem .feedback-item-activity,
+.feedback-item-group .feedback-item-activity,
+.feedbackItemGroupItem .feedback-item-activity {
+  @apply flex items-center gap-2 mx-4 mt-2.5;
+}
+
+.feedbackItem .feedback-item-activity .feedback-item-activity-avatar,
+.feedback-item-group .feedback-item-activity .feedback-item-activity-avatar,
+.feedbackItemGroupItem .feedback-item-activity .feedback-item-activity-avatar {
+  @apply shrink-0;
+}
+
+.feedbackItem .feedback-item-activity .feedback-item-activity-details,
+.feedback-item-group .feedback-item-activity .feedback-item-activity-details,
+.feedbackItemGroupItem .feedback-item-activity .feedback-item-activity-details {
+  @apply min-w-0;
+}
+
+.feedbackItem .feedback-item-activity .feedback-item-activity-author,
+.feedback-item-group .feedback-item-activity .feedback-item-activity-author,
+.feedbackItemGroupItem .feedback-item-activity .feedback-item-activity-author,
+.feedbackItem .feedback-item-activity .feedback-item-activity-time,
+.feedback-item-group .feedback-item-activity .feedback-item-activity-time,
+.feedbackItemGroupItem .feedback-item-activity .feedback-item-activity-time {
+  @apply text-(--text-secondary-color);
 }
 
 .focus-outline-primary {

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -691,11 +691,11 @@ div.ms-Tooltip-content p.ms-Tooltip-subtext a {
         @apply flex pr-2.5;
 
         & .permission-image {
-          @apply w-11 min-w-11 max-w-11 h-11 rounded-full flex items-center justify-center text-(--text-primary-color) bg-(--background-color);
+          @apply w-8 min-w-8 max-w-8 h-8 rounded-full flex items-center justify-center text-(--text-primary-color) bg-(--background-color);
 
           & .avatar,
           & .avatar-fallback {
-            @apply w-11 h-11;
+            @apply w-8 h-8;
           }
         }
       }

--- a/src/frontend/utilities/avatarFallbackHelper.ts
+++ b/src/frontend/utilities/avatarFallbackHelper.ts
@@ -1,0 +1,52 @@
+export type IdentityAvatarReference = {
+  displayName?: string;
+  imageUrl?: string;
+  _links?: {
+    avatar?: {
+      href?: string;
+    };
+  };
+};
+
+const FLUENT_PERSONA_COLOR_SWATCHES = ["#4F6BED", "#0078D4", "#004E8C", "#038387", "#498205", "#0B6A0B", "#C239B3", "#E3008C", "#881798", "#5C2E91", "#CA5010", "#D13438", "#A4262C", "#8764B8", "#986F0B", "#750B1C", "#7A7574", "#005B70", "#8E562E", "#69797E"];
+
+export const getAvatarImageUrl = (identity?: IdentityAvatarReference | null): string | undefined => {
+  return identity?._links?.avatar?.href || identity?.imageUrl || undefined;
+};
+
+export const getIdentityInitials = (name?: string): string => {
+  if (!name) {
+    return "?";
+  }
+
+  const tokens = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (!tokens.length) {
+    return "?";
+  }
+
+  if (tokens.length === 1) {
+    return tokens[0].slice(0, 2).toUpperCase();
+  }
+
+  return `${tokens[0][0]}${tokens[1][0]}`.toUpperCase();
+};
+
+export const getIdentityColor = (name?: string): string => {
+  const displayName = name || "";
+  if (!displayName) {
+    return "#0078D4";
+  }
+
+  let hashCode = 0;
+  for (let index = displayName.length - 1; index >= 0; index--) {
+    const characterCode = displayName.charCodeAt(index);
+    const shift = index % 8;
+    hashCode ^= (characterCode << shift) + (characterCode >> (8 - shift));
+  }
+
+  return FLUENT_PERSONA_COLOR_SWATCHES[Math.abs(hashCode) % FLUENT_PERSONA_COLOR_SWATCHES.length];
+};

--- a/src/frontend/utilities/avatarFallbackHelper.ts
+++ b/src/frontend/utilities/avatarFallbackHelper.ts
@@ -8,8 +8,6 @@ export type IdentityAvatarReference = {
   };
 };
 
-const FLUENT_PERSONA_COLOR_SWATCHES = ["#4F6BED", "#0078D4", "#004E8C", "#038387", "#498205", "#0B6A0B", "#C239B3", "#E3008C", "#881798", "#5C2E91", "#CA5010", "#D13438", "#A4262C", "#8764B8", "#986F0B", "#750B1C", "#7A7574", "#005B70", "#8E562E", "#69797E"];
-
 export const getAvatarImageUrl = (identity?: IdentityAvatarReference | null): string | undefined => {
   return identity?._links?.avatar?.href || identity?.imageUrl || undefined;
 };
@@ -48,5 +46,6 @@ export const getIdentityColor = (seed?: string, nameFallback?: string): string =
     hashCode ^= (characterCode << shift) + (characterCode >> (8 - shift));
   }
 
-  return FLUENT_PERSONA_COLOR_SWATCHES[Math.abs(hashCode) % FLUENT_PERSONA_COLOR_SWATCHES.length];
+  const hue = Math.abs(hashCode) % 360;
+  return `hsl(${hue} 70% 42%)`;
 };

--- a/src/frontend/utilities/avatarFallbackHelper.ts
+++ b/src/frontend/utilities/avatarFallbackHelper.ts
@@ -39,17 +39,17 @@ export const getIdentityColor = (seed?: string, nameFallback?: string): string =
     return "#0078D4";
   }
 
-  let hashCode = 0;
-  for (let index = valueToHash.length - 1; index >= 0; index--) {
-    const characterCode = valueToHash.charCodeAt(index);
-    const shift = index % 8;
-    hashCode ^= (characterCode << shift) + (characterCode >> (8 - shift));
+  // FNV-1a 32-bit for lower collision rate than the previous XOR-shift hash.
+  let hashCode = 0x811c9dc5;
+  for (let index = 0; index < valueToHash.length; index++) {
+    hashCode ^= valueToHash.charCodeAt(index);
+    hashCode = Math.imul(hashCode, 0x01000193);
   }
 
   const normalizedHash = hashCode >>> 0;
   const hue = normalizedHash % 360;
-  const saturation = 62 + ((normalizedHash >>> 9) % 16); // 62-77%
-  const lightness = 36 + ((normalizedHash >>> 17) % 14); // 36-49%
+  const saturation = 65 + ((normalizedHash >>> 10) % 16); // 65-80%
+  const lightness = 38 + ((normalizedHash >>> 18) % 12); // 38-49%
 
   return `hsl(${hue} ${saturation}% ${lightness}%)`;
 };

--- a/src/frontend/utilities/avatarFallbackHelper.ts
+++ b/src/frontend/utilities/avatarFallbackHelper.ts
@@ -35,15 +35,15 @@ export const getIdentityInitials = (name?: string): string => {
   return `${tokens[0][0]}${tokens[1][0]}`.toUpperCase();
 };
 
-export const getIdentityColor = (name?: string): string => {
-  const displayName = name || "";
-  if (!displayName) {
+export const getIdentityColor = (seed?: string, nameFallback?: string): string => {
+  const valueToHash = seed || nameFallback || "";
+  if (!valueToHash) {
     return "#0078D4";
   }
 
   let hashCode = 0;
-  for (let index = displayName.length - 1; index >= 0; index--) {
-    const characterCode = displayName.charCodeAt(index);
+  for (let index = valueToHash.length - 1; index >= 0; index--) {
+    const characterCode = valueToHash.charCodeAt(index);
     const shift = index % 8;
     hashCode ^= (characterCode << shift) + (characterCode >> (8 - shift));
   }

--- a/src/frontend/utilities/avatarFallbackHelper.ts
+++ b/src/frontend/utilities/avatarFallbackHelper.ts
@@ -46,6 +46,10 @@ export const getIdentityColor = (seed?: string, nameFallback?: string): string =
     hashCode ^= (characterCode << shift) + (characterCode >> (8 - shift));
   }
 
-  const hue = Math.abs(hashCode) % 360;
-  return `hsl(${hue} 70% 42%)`;
+  const normalizedHash = hashCode >>> 0;
+  const hue = normalizedHash % 360;
+  const saturation = 62 + ((normalizedHash >>> 9) % 16); // 62-77%
+  const lightness = 36 + ((normalizedHash >>> 17) % 14); // 36-49%
+
+  return `hsl(${hue} ${saturation}% ${lightness}%)`;
 };


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): #1887

## Description

Refactor avatar rendering to use same logic throughout extension with robust initial fallback.

## Bug or Feature?

- [x] Bug fix
- [ ] New feature

## Fundamentals

- [x] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly.
- [ ] I have added either the `docs updated` or `docs not needed` label to this PR.
- [ ] If I used `docs updated`, I updated the relevant release-facing content, such as `CHANGELOG.md`, What's New, `README.md`, or `src/frontend/assets/PACKAGE-DESCRIPTION.md`.
  - [ ] If I updated `CHANGELOG.md`, I included a link to this PR in that blurb.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Accessibility

- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

<!-- Do you have any screenshots or logs that would show off your fix? -->
